### PR TITLE
feat(openapi): add SpringDoc OpenAPI documentation with Swagger UI

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -1,0 +1,169 @@
+name: Update API Documentation
+
+on:
+  workflow_run:
+    workflows: ["CD"]
+    types:
+      - completed
+    branches:
+      - main
+      - dev
+
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Entorno desde el cual obtener la spec'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - prod
+
+permissions:
+  contents: write
+
+env:
+  API_URL_DEV: https://david-whoop-dev.apptolast.com
+  API_URL_PROD: https://david-whoop.apptolast.com
+
+jobs:
+  update-docs:
+    name: Update OpenAPI & Postman Collection
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install openapi-to-postmanv2
+        run: npm install -g openapi-to-postmanv2
+
+      - name: Determine API URL
+        id: api-url
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ENV="${{ github.event.inputs.environment }}"
+          elif [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+            ENV="prod"
+          else
+            ENV="dev"
+          fi
+
+          if [ "$ENV" = "prod" ]; then
+            echo "url=${{ env.API_URL_PROD }}" >> $GITHUB_OUTPUT
+          else
+            echo "url=${{ env.API_URL_DEV }}" >> $GITHUB_OUTPUT
+          fi
+          echo "env=$ENV" >> $GITHUB_OUTPUT
+
+      - name: Wait for API deployment
+        run: |
+          echo "Esperando 60 segundos para que el deployment complete..."
+          sleep 60
+
+      - name: Fetch OpenAPI spec
+        id: fetch-spec
+        run: |
+          API_URL="${{ steps.api-url.outputs.url }}"
+          echo "Obteniendo OpenAPI spec desde: $API_URL/v3/api-docs"
+
+          for i in 1 2 3; do
+            HTTP_CODE=$(curl -s -w "%{http_code}" -o openapi.json "$API_URL/v3/api-docs")
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "OpenAPI spec obtenido exitosamente"
+              cat openapi.json | jq '.' > openapi_formatted.json
+              mv openapi_formatted.json openapi.json
+              break
+            fi
+            echo "Intento $i fallido (HTTP $HTTP_CODE), esperando 30 segundos..."
+            sleep 30
+          done
+
+          if [ ! -s openapi.json ]; then
+            echo "Error: No se pudo obtener el OpenAPI spec"
+            exit 1
+          fi
+
+          echo "Tamano del spec: $(wc -c < openapi.json) bytes"
+
+      - name: Generate Postman Collection
+        run: |
+          echo "Generando Postman Collection desde OpenAPI spec..."
+
+          openapi2postmanv2 \
+            -s openapi.json \
+            -o WhoopDavidAPI_Collection_NEW.postman_collection.json \
+            -p \
+            -O folderStrategy=Tags,includeAuthInfoInExample=true
+
+          if [ ! -s WhoopDavidAPI_Collection_NEW.postman_collection.json ]; then
+            echo "Error: No se pudo generar la coleccion Postman"
+            exit 1
+          fi
+
+          echo "Coleccion Postman generada exitosamente"
+
+      - name: Update collection metadata
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch || github.ref_name }}"
+          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          ENV="${{ steps.api-url.outputs.env }}"
+
+          jq --arg date "$DATE" --arg branch "$BRANCH" --arg env "$ENV" '
+            .info.name = "Whoop David API - Auto-generated" |
+            .info.description = "Coleccion generada automaticamente desde OpenAPI spec.\n\nFecha: \($date)\nRama: \($branch)\nEntorno: \($env)\n\nGenerado por GitHub Actions workflow."
+          ' WhoopDavidAPI_Collection_NEW.postman_collection.json > temp.json
+          mv temp.json WhoopDavidAPI_Collection.postman_collection.json
+          rm -f WhoopDavidAPI_Collection_NEW.postman_collection.json
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git diff --quiet openapi.json WhoopDavidAPI_Collection.postman_collection.json 2>/dev/null || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          git add openapi.json WhoopDavidAPI_Collection.postman_collection.json
+
+          BRANCH="${{ github.event.workflow_run.head_branch || github.ref_name }}"
+          ENV="${{ steps.api-url.outputs.env }}"
+
+          git commit -m "docs: auto-update OpenAPI spec and Postman collection
+
+          - Updated from $ENV environment API
+          - Branch: $BRANCH
+          - Generated by GitHub Actions
+
+          Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+
+          git push
+
+      - name: Summary
+        run: |
+          echo "## API Documentation Update" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Environment | ${{ steps.api-url.outputs.env }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| API URL | ${{ steps.api-url.outputs.url }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| OpenAPI Spec | Updated |" >> $GITHUB_STEP_SUMMARY
+          echo "| Postman Collection | Updated |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.changes.outputs.changed }}" = "true" ]; then
+            echo "| Commit | Pushed |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Commit | No changes |" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     implementation("io.github.resilience4j:resilience4j-spring-boot3:2.3.0")
     implementation("org.springframework.boot:spring-boot-starter-aspectj")
 
+    // OpenAPI / Swagger UI (v3.x para Spring Boot 4)
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
+
     // Database drivers
     runtimeOnly("com.h2database:h2")
     runtimeOnly("org.postgresql:postgresql")

--- a/src/main/kotlin/com/example/whoopdavidapi/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/example/whoopdavidapi/config/OpenApiConfig.kt
@@ -1,0 +1,77 @@
+package com.example.whoopdavidapi.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun customOpenAPI(): OpenAPI {
+        val securitySchemeName = "basicAuth"
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("Whoop David API")
+                    .description(
+                        """
+                        API REST intermediaria entre Whoop API v2 y Power BI.
+
+                        **Patron BFF (Backend For Frontend)** para un solo usuario.
+
+                        **Datos disponibles:**
+                        - Cycles (ciclos fisiologicos)
+                        - Recovery (puntuacion de recuperacion)
+                        - Sleep (datos de sueno)
+                        - Workouts (entrenamientos)
+                        - Profile (perfil del usuario)
+
+                        **Autenticacion:** HTTP Basic Auth (usuario/password de Power BI)
+                        """.trimIndent()
+                    )
+                    .version("1.0.0")
+                    .contact(
+                        Contact()
+                            .name("AppToLast")
+                            .url("https://apptolast.com")
+                    )
+                    .license(
+                        License()
+                            .name("Apache 2.0")
+                            .url("https://www.apache.org/licenses/LICENSE-2.0")
+                    )
+            )
+            .addSecurityItem(SecurityRequirement().addList(securitySchemeName))
+            .components(
+                Components()
+                    .addSecuritySchemes(
+                        securitySchemeName,
+                        SecurityScheme()
+                            .name(securitySchemeName)
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("basic")
+                    )
+            )
+            .servers(
+                listOf(
+                    Server()
+                        .url("https://david-whoop-dev.apptolast.com")
+                        .description("Servidor de desarrollo (DEV)"),
+                    Server()
+                        .url("https://david-whoop.apptolast.com")
+                        .description("Servidor de produccion (PROD)"),
+                    Server()
+                        .url("http://localhost:8080")
+                        .description("Servidor local (desarrollo)")
+                )
+            )
+    }
+}

--- a/src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt
@@ -65,7 +65,10 @@ class SecurityConfig(
     @Order(3)
     fun publicSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
-            .securityMatcher("/actuator/**", "/h2-console/**", "/mock/**")
+            .securityMatcher(
+                "/actuator/**", "/h2-console/**", "/mock/**",
+                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
+            )
             .csrf { it.disable() }
             .headers { headers -> headers.frameOptions { it.sameOrigin() } }
             .authorizeHttpRequests { auth ->

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,20 @@ spring:
             user-info-uri: https://api.prod.whoop.com/developer/v1/user/profile/basic
             user-name-attribute: user_id
 
+# SpringDoc OpenAPI / Swagger UI
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+    operations-sorter: method
+    tags-sorter: alpha
+    try-it-out-enabled: true
+    display-request-duration: true
+  show-actuator: false
+
 # Actuator
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- Add `springdoc-openapi-starter-webmvc-ui:3.0.1` (compatible with Spring Boot 4.0.2)
- Create `OpenApiConfig` with server URLs for Postman/Swagger import:
  - DEV: `https://david-whoop-dev.apptolast.com`
  - PROD: `https://david-whoop.apptolast.com`
  - Local: `http://localhost:8080`
- Configure HTTP Basic Auth security scheme in OpenAPI spec
- Expose `/v3/api-docs/**` and `/swagger-ui/**` as public endpoints in SecurityConfig
- Add springdoc configuration in `application.yaml`
- Add GitHub Actions workflow (`update-api-docs.yml`) for auto-generating OpenAPI spec and Postman collection after CD deploys

## Endpoints added
| Endpoint | Description |
|----------|-------------|
| `/v3/api-docs` | OpenAPI 3.1 JSON specification |
| `/swagger-ui.html` | Swagger UI interactive interface |

## Test plan
- [x] `./gradlew build` passes (0 errors, 0 warnings)
- [x] All 9 existing tests pass
- [ ] After merge+deploy: verify `/v3/api-docs` returns JSON spec
- [ ] After merge+deploy: verify `/swagger-ui.html` loads UI
- [ ] After deploy: verify `update-api-docs.yml` workflow generates openapi.json and Postman collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)