### PR TITLE
feat: add JSON pretty-print for OpenAPI spec

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,7 @@ springdoc:
     try-it-out-enabled: true
     display-request-duration: true
   show-actuator: false
+  writer-with-default-pretty-printer: true
 
 # Actuator
 management:


### PR DESCRIPTION
## Summary
- Add `springdoc.writer-with-default-pretty-printer=true` so `/v3/api-docs` returns formatted JSON
- Makes the OpenAPI spec compatible with browser JSON viewer extensions (JSON Viewer Pro, etc.)

## Test plan
- [x] `./gradlew build` passes
- [ ] After deploy: `curl /v3/api-docs` returns indented JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)