### PR TITLE
docs: add Spring Boot learning documentation (15 guides)

### DIFF
--- a/docs/00-indice.md
+++ b/docs/00-indice.md
@@ -1,0 +1,204 @@
+# Whoop David API - Documentacion de Aprendizaje
+
+## Bienvenido
+
+Esta documentacion esta disenada para ensenar cada concepto de Spring Boot utilizado en este proyecto. No es una referencia rapida, sino una **guia de aprendizaje** donde cada decision tecnica esta explicada con el "por que" detras.
+
+**WhoopDavidAPI** es una API REST intermediaria que sigue el patron **BFF (Backend For Frontend)**. Su proposito es:
+
+1. **Conectarse** a la Whoop API v2 (la API oficial de la pulsera Whoop)
+2. **Sincronizar** los datos de salud y fitness en una base de datos PostgreSQL local
+3. **Exponer** esos datos a traves de una API REST propia, consumida por Power BI para visualizacion
+
+Es un proyecto de un **unico usuario** (David), lo que simplifica muchas decisiones arquitectonicas.
+
+---
+
+## Patron BFF (Backend For Frontend)
+
+```
+┌─────────────┐       ┌──────────────────────┐       ┌─────────────┐
+│  Whoop API  │──────>│   WhoopDavidAPI (BFF) │──────>│  Power BI   │
+│    v2        │  sync │                      │  REST │  Dashboard  │
+└─────────────┘       │  ┌──────────────────┐ │       └─────────────┘
+                      │  │   PostgreSQL     │ │
+                      │  │   (almacen)      │ │
+                      │  └──────────────────┘ │
+                      └──────────────────────┘
+```
+
+El BFF actua como intermediario: no expone directamente la API de Whoop, sino que almacena los datos localmente y los sirve en el formato que Power BI necesita. Esto evita depender de la disponibilidad de Whoop en tiempo real y permite paginacion, filtrado y transformacion de datos.
+
+---
+
+## Stack tecnologico
+
+| Tecnologia | Version | Proposito |
+|---|---|---|
+| **Kotlin** | 2.2.21 | Lenguaje principal |
+| **Spring Boot** | 4.0.2 | Framework backend |
+| **Java** | 24 | JVM runtime |
+| **PostgreSQL** | - | Base de datos en produccion |
+| **H2** | - | Base de datos en desarrollo (in-memory) |
+| **MapStruct** | 1.6.3 | Mapeo Entity <-> DTO |
+| **Resilience4j** | 2.3.0 | Circuit breaker, retry, rate limiter |
+| **springdoc-openapi** | 3.0.1 | Documentacion Swagger UI |
+| **Gradle** | - | Build system (Kotlin DSL) |
+| **Docker** | - | Contenedorizacion |
+| **Kubernetes** | RKE2 | Orquestacion en produccion |
+
+---
+
+## Swagger UI (API interactiva)
+
+| Entorno | URL |
+|---|---|
+| **DEV** | [https://david-whoop-dev.apptolast.com/swagger-ui/index.html](https://david-whoop-dev.apptolast.com/swagger-ui/index.html) |
+| **PROD** | [https://david-whoop.apptolast.com/swagger-ui/index.html](https://david-whoop.apptolast.com/swagger-ui/index.html) |
+
+---
+
+## Estructura del proyecto
+
+```
+WhoopDavidAPI/
+├── build.gradle.kts                          # Configuracion de Gradle y dependencias
+├── settings.gradle.kts                       # Nombre del proyecto raiz
+├── Dockerfile                                # Multi-stage build para Docker
+├── k8s/                                      # Manifiestos de Kubernetes
+│   ├── 00-namespace.yaml
+│   ├── 01-postgresql/
+│   ├── 02-api-dev/
+│   └── 03-api-prod/
+├── .github/workflows/                        # CI/CD con GitHub Actions
+│   ├── ci.yml
+│   ├── cd.yml
+│   └── update-api-docs.yml
+│
+├── src/main/resources/
+│   ├── application.yaml                      # Configuracion base (compartida)
+│   ├── application-dev.yaml                  # Perfil dev: H2, logs DEBUG
+│   ├── application-prod.yaml                 # Perfil prod: PostgreSQL, logs INFO
+│   └── application-demo.yaml                 # Perfil demo: mock API, sin keys reales
+│
+├── src/main/kotlin/com/example/whoopdavidapi/
+│   ├── WhoopDavidApiApplication.kt           # Punto de entrada (@SpringBootApplication)
+│   │
+│   ├── config/                               # Configuracion de Spring
+│   │   ├── SecurityConfig.kt                 # 4 cadenas de seguridad (Basic Auth, OAuth2, public, deny)
+│   │   ├── WhoopClientConfig.kt              # Bean RestClient con timeouts
+│   │   └── OpenApiConfig.kt                  # Configuracion de Swagger/OpenAPI
+│   │
+│   ├── model/
+│   │   ├── entity/                           # Entidades JPA (tablas de BD)
+│   │   │   ├── WhoopCycle.kt                 # Ciclos fisiologicos
+│   │   │   ├── WhoopRecovery.kt              # Puntuaciones de recuperacion
+│   │   │   ├── WhoopSleep.kt                 # Datos de sueno
+│   │   │   ├── WhoopWorkout.kt               # Entrenamientos
+│   │   │   └── OAuthTokenEntity.kt           # Tokens OAuth2 (cifrados con AES-256-GCM)
+│   │   └── dto/                              # Data Transfer Objects (respuestas API)
+│   │       ├── CycleDTO.kt
+│   │       ├── RecoveryDTO.kt
+│   │       ├── SleepDTO.kt
+│   │       ├── WorkoutDTO.kt
+│   │       └── PaginatedResponse.kt          # Wrapper generico de paginacion
+│   │
+│   ├── repository/                           # Spring Data JPA Repositories
+│   │   ├── CycleRepository.kt
+│   │   ├── RecoveryRepository.kt
+│   │   ├── SleepRepository.kt
+│   │   ├── WorkoutRepository.kt
+│   │   └── OAuthTokenRepository.kt
+│   │
+│   ├── mapper/                               # MapStruct mappers (Entity <-> DTO)
+│   │   ├── CycleMapper.kt
+│   │   ├── RecoveryMapper.kt
+│   │   ├── SleepMapper.kt
+│   │   └── WorkoutMapper.kt
+│   │
+│   ├── service/                              # Logica de negocio
+│   │   ├── CycleService.kt
+│   │   ├── RecoveryService.kt
+│   │   ├── SleepService.kt
+│   │   ├── WorkoutService.kt
+│   │   └── WhoopSyncService.kt              # Sincronizacion incremental con Whoop API
+│   │
+│   ├── controller/                           # Controladores REST (/api/v1/...)
+│   │   ├── CycleController.kt
+│   │   ├── RecoveryController.kt
+│   │   ├── SleepController.kt
+│   │   ├── WorkoutController.kt
+│   │   └── ProfileController.kt
+│   │
+│   ├── client/                               # Cliente HTTP para Whoop API
+│   │   ├── TokenManager.kt                   # Interface para abstraccion de tokens
+│   │   ├── WhoopApiClient.kt                 # RestClient + Resilience4j
+│   │   └── WhoopTokenManager.kt              # Gestion de tokens OAuth2 (refresh automatico)
+│   │
+│   ├── scheduler/                            # Tareas programadas
+│   │   └── WhoopDataSyncScheduler.kt        # @Scheduled con cron configurable
+│   │
+│   ├── exception/                            # Manejo global de errores
+│   │   ├── WhoopApiException.kt              # Excepcion custom para errores de Whoop API
+│   │   └── GlobalExceptionHandler.kt         # @RestControllerAdvice
+│   │
+│   ├── mock/                                 # Perfil demo (sin API keys reales)
+│   │   ├── MockWhoopApiController.kt         # Endpoints mock que simulan Whoop API
+│   │   ├── MockWhoopDataGenerator.kt         # Generador de datos realistas (seed=42)
+│   │   ├── DemoWhoopTokenManager.kt          # TokenManager falso para demo
+│   │   └── DemoTokenSeeder.kt                # Inserta token demo al arrancar
+│   │
+│   └── util/                                 # Utilidades
+│       ├── TokenEncryptor.kt                 # AES-256-GCM para cifrar tokens en BD
+│       └── EncryptedStringConverter.kt       # JPA AttributeConverter automatico
+│
+└── src/test/kotlin/com/example/whoopdavidapi/
+    ├── WhoopDavidApiApplicationTests.kt      # Test de carga del contexto
+    ├── controller/CycleControllerTest.kt     # Tests de integracion del controlador
+    ├── repository/CycleRepositoryTest.kt     # Tests del repositorio con H2
+    └── service/CycleServiceTest.kt           # Tests unitarios del servicio
+```
+
+---
+
+## Indice de documentacion
+
+Cada documento explica un concepto de Spring Boot con referencias al codigo real del proyecto:
+
+| # | Documento | Descripcion |
+|---|---|---|
+| **01** | [Arquitectura y patron BFF](01-arquitectura.md) | Arquitectura general, flujo de datos, por que WebMVC y no WebFlux |
+| **02** | [Gradle y dependencias](02-gradle-dependencias.md) | Cada dependencia explicada, plugins de Kotlin, gotchas de Spring Boot 4 |
+| **03** | [Entidades JPA e Hibernate](03-entidades-jpa.md) | `@Entity`, `@Table`, `@Column`, tipos de datos, cifrado de tokens |
+| **04** | [Spring Data JPA Repositories](04-repositorios.md) | Interfaces, derived queries, paginacion, `JpaRepository` |
+| **05** | [DTOs y MapStruct](05-dtos-mapstruct.md) | Separacion Entity/DTO, mappers automaticos con kapt |
+| **06** | [Capa de servicios](06-servicios.md) | `@Service`, logica de negocio, `WhoopSyncService` |
+| **07** | [Controladores REST](07-controladores.md) | `@RestController`, `@GetMapping`, validacion, `ResponseEntity` |
+| **08** | [Spring Security](08-seguridad.md) | Multi-chain: Basic Auth, OAuth2, endpoints publicos, deny-all |
+| **09** | [RestClient y Resilience4j](09-cliente-http.md) | Cliente HTTP, circuit breaker, retry, rate limiter |
+| **10** | [Sincronizacion programada](10-sincronizacion.md) | `@Scheduled`, cron, sincronizacion incremental |
+| **11** | [Perfiles de Spring](11-perfiles.md) | dev/prod/demo, `@Profile`, configuracion por entorno |
+| **12** | [Testing en Spring Boot](12-testing.md) | `@SpringBootTest`, `@DataJpaTest`, `@MockitoBean`, MockMvc |
+| **13** | [Docker y Kubernetes](13-docker-k8s.md) | Multi-stage Dockerfile, K8s manifests, Traefik, cert-manager |
+| **14** | [CI/CD con GitHub Actions](14-cicd.md) | Workflows de CI (test), CD (deploy), actualizacion de docs |
+
+---
+
+## Como usar esta documentacion
+
+1. **Lee en orden** si eres nuevo en Spring Boot: empieza por la arquitectura (01) y avanza secuencialmente
+2. **Salta a lo que necesites** si buscas algo concreto: cada documento es autocontenido
+3. **Sigue los links al codigo**: cada documento referencia los archivos fuente reales con rutas relativas clickeables en GitHub
+4. **Consulta la documentacion oficial**: cada documento incluye links a la documentacion oficial de Spring Boot y Kotlin
+
+---
+
+## Documentacion oficial de referencia
+
+- [Spring Boot 4.0.x Reference](https://docs.spring.io/spring-boot/reference/)
+- [Kotlin Language Reference](https://kotlinlang.org/docs/reference/)
+- [Spring Data JPA Reference](https://docs.spring.io/spring-data/jpa/reference/)
+- [Spring Security Reference](https://docs.spring.io/spring-security/reference/)
+- [Resilience4j Documentation](https://resilience4j.readme.io/docs)
+- [MapStruct Reference Guide](https://mapstruct.org/documentation/stable/reference/html/)
+- [springdoc-openapi](https://springdoc.org/)

--- a/docs/01-arquitectura.md
+++ b/docs/01-arquitectura.md
@@ -1,0 +1,334 @@
+# 01 - Arquitectura y Patron BFF
+
+## Que es?
+
+La **arquitectura** de una aplicacion define como se organizan sus componentes y como fluyen los datos entre ellos. En este proyecto usamos dos conceptos clave:
+
+1. **Patron BFF (Backend For Frontend)**: Un servidor intermedio que adapta una API externa al formato que necesita un cliente especifico
+2. **Arquitectura por capas**: Separacion de responsabilidades en Controller, Service, Repository y Database
+
+### Que es el patron BFF?
+
+BFF significa **Backend For Frontend**. Es un patron donde creas un servidor backend dedicado a un frontend especifico. En nuestro caso:
+
+- **Frontend**: Power BI (el dashboard de visualizacion)
+- **Backend externo**: Whoop API v2 (la API oficial de la pulsera Whoop)
+- **BFF**: WhoopDavidAPI (este proyecto)
+
+Sin un BFF, Power BI tendria que:
+- Autenticarse directamente contra Whoop API (OAuth2 complejo)
+- Manejar paginacion de Whoop (tokens de siguiente pagina)
+- Depender de que Whoop este online en cada refresco del dashboard
+- Transformar formatos JSON anidados al formato tabular que necesita
+
+Con el BFF, Power BI simplemente hace peticiones HTTP Basic Auth a nuestra API, que devuelve datos ya almacenados, paginados y en formato plano.
+
+---
+
+## Donde se usa en este proyecto?
+
+### Punto de entrada
+
+**Archivo**: [`src/main/kotlin/com/example/whoopdavidapi/WhoopDavidApiApplication.kt`](../src/main/kotlin/com/example/whoopdavidapi/WhoopDavidApiApplication.kt)
+
+```kotlin
+@SpringBootApplication
+@EnableScheduling
+class WhoopDavidApiApplication
+
+fun main(args: Array<String>) {
+    runApplication<WhoopDavidApiApplication>(*args)
+}
+```
+
+### Componentes clave por capa
+
+| Capa | Archivos | Responsabilidad |
+|---|---|---|
+| **Controller** | [`controller/CycleController.kt`](../src/main/kotlin/com/example/whoopdavidapi/controller/CycleController.kt), etc. | Recibir peticiones HTTP, validar parametros, devolver respuestas |
+| **Service** | [`service/CycleService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/CycleService.kt), etc. | Logica de negocio, transformacion de datos |
+| **Repository** | [`repository/CycleRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/CycleRepository.kt), etc. | Acceso a base de datos (queries JPA) |
+| **Entity** | [`model/entity/WhoopCycle.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/WhoopCycle.kt), etc. | Representacion de tablas de BD |
+| **DTO** | [`model/dto/CycleDTO.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/CycleDTO.kt), etc. | Objetos de transferencia para respuestas API |
+| **Mapper** | [`mapper/CycleMapper.kt`](../src/main/kotlin/com/example/whoopdavidapi/mapper/CycleMapper.kt), etc. | Conversion automatica Entity <-> DTO |
+| **Client** | [`client/WhoopApiClient.kt`](../src/main/kotlin/com/example/whoopdavidapi/client/WhoopApiClient.kt) | Cliente HTTP para Whoop API externa |
+| **Sync** | [`service/WhoopSyncService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt) | Sincronizacion de datos Whoop -> BD local |
+| **Scheduler** | [`scheduler/WhoopDataSyncScheduler.kt`](../src/main/kotlin/com/example/whoopdavidapi/scheduler/WhoopDataSyncScheduler.kt) | Disparo periodico de la sincronizacion |
+| **Security** | [`config/SecurityConfig.kt`](../src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt) | Autenticacion y autorizacion |
+| **Exception** | [`exception/GlobalExceptionHandler.kt`](../src/main/kotlin/com/example/whoopdavidapi/exception/GlobalExceptionHandler.kt) | Manejo centralizado de errores |
+
+---
+
+## Diagrama de flujo de datos
+
+```
+                    SINCRONIZACION (cada 30 min via @Scheduled)
+                    ==========================================
+
+┌──────────────────┐     ┌──────────────────┐     ┌────────────────────┐     ┌─────────────┐
+│   Whoop API v2   │────>│  WhoopApiClient  │────>│  WhoopSyncService  │────>│ PostgreSQL  │
+│ (API externa)    │     │  (RestClient +   │     │  (mapea JSON a     │     │ (almacen    │
+│                  │     │   Resilience4j)  │     │   entidades JPA)   │     │  local)     │
+└──────────────────┘     └──────────────────┘     └────────────────────┘     └─────────────┘
+       ^                        ^                                                  │
+       │                        │                                                  │
+  OAuth2 Bearer           Token auto-refresh                                       │
+  token                   via WhoopTokenManager                                    │
+                                                                                   │
+                    CONSULTA (Power BI via HTTP Basic Auth)                         │
+                    ==========================================                     │
+                                                                                   v
+┌──────────────────┐     ┌──────────────────┐     ┌────────────────────┐     ┌─────────────┐
+│    Power BI      │<────│   Controllers    │<────│     Services       │<────│ Repositories│
+│   (dashboard)    │     │  (REST /api/v1)  │     │  (paginacion,      │     │ (JPA queries│
+│                  │     │                  │     │   filtrado)        │     │  a la BD)   │
+└──────────────────┘     └──────────────────┘     └────────────────────┘     └─────────────┘
+                              │
+                         Basic Auth
+                         (usuario: powerbi)
+```
+
+### Flujo de sincronizacion (escritura)
+
+1. `WhoopDataSyncScheduler` dispara `syncAll()` cada 30 minutos (configurable via cron)
+2. `WhoopSyncService` pide los datos a `WhoopApiClient` con sincronizacion incremental (solo datos nuevos desde el ultimo `updatedAt`)
+3. `WhoopApiClient` usa `RestClient` para llamar a Whoop API v2 con token Bearer OAuth2
+4. `WhoopTokenManager` se asegura de que el token sea valido; si expira en menos de 5 minutos, lo refresca automaticamente
+5. `WhoopSyncService` mapea las respuestas JSON a entidades JPA y las guarda en la BD
+
+### Flujo de consulta (lectura)
+
+1. Power BI hace `GET /api/v1/cycles?page=1&pageSize=100` con HTTP Basic Auth
+2. `SecurityConfig` valida las credenciales (usuario `powerbi`)
+3. `CycleController` valida los parametros y delega a `CycleService`
+4. `CycleService` consulta `CycleRepository` con paginacion y filtros
+5. El resultado se convierte de Entity a DTO via `CycleMapper` (MapStruct)
+6. Se devuelve un `PaginatedResponse<CycleDTO>` como JSON
+
+---
+
+## Por que esta decision?
+
+### Por que WebMVC y no WebFlux?
+
+Spring ofrece dos modelos de programacion web:
+
+| Caracteristica | WebMVC (elegido) | WebFlux |
+|---|---|---|
+| Modelo | Bloqueante (un hilo por request) | No bloqueante (reactivo) |
+| JPA/Hibernate | Compatible directamente | Requiere R2DBC (diferente ORM) |
+| `@Scheduled` | Funciona nativo | Requiere adaptaciones |
+| Complejidad | Simple | Mas complejo (Mono/Flux) |
+| Beneficio reactivo | No necesario (1 usuario) | Miles de conexiones concurrentes |
+
+**Decisiones que forzaron WebMVC:**
+
+1. **JPA es bloqueante**: Spring Data JPA (Hibernate) usa JDBC, que es bloqueante por naturaleza. Usar WebFlux con JPA anularia las ventajas reactivas
+2. **`@Scheduled` es bloqueante**: La sincronizacion periodica usa hilos bloqueantes
+3. **Un solo usuario**: No hay beneficio en manejar miles de conexiones concurrentes cuando solo Power BI hace peticiones
+
+### Por que sincronizacion incremental?
+
+En [`service/WhoopSyncService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt), cada metodo `sync*()` busca el ultimo `updatedAt` en la BD:
+
+```kotlin
+private fun syncCycles() {
+    try {
+        // Sincronizacion incremental: obtener solo datos nuevos
+        val lastUpdated = cycleRepository.findTopByOrderByUpdatedAtDesc()?.updatedAt
+        val records = whoopApiClient.getAllCycles(start = lastUpdated)
+        // ...
+    }
+}
+```
+
+Esto evita descargar todos los datos en cada sincronizacion. En la primera ejecucion, `lastUpdated` es `null` y se descargan todos los datos historicos. En ejecuciones siguientes, solo se piden los datos actualizados despues de la ultima sincronizacion.
+
+### Por que separar Entity y DTO?
+
+Las **entidades** (`WhoopCycle`) representan la estructura de la base de datos. Los **DTOs** (`CycleDTO`) representan lo que la API devuelve al cliente. Separarlos permite:
+
+- Cambiar la estructura de la BD sin afectar la API
+- Ocultar campos internos (como timestamps de sincronizacion)
+- Devolver formatos diferentes a distintos clientes en el futuro
+
+---
+
+## Codigo explicado
+
+### Punto de entrada: `WhoopDavidApiApplication.kt`
+
+**Archivo**: [`src/main/kotlin/com/example/whoopdavidapi/WhoopDavidApiApplication.kt`](../src/main/kotlin/com/example/whoopdavidapi/WhoopDavidApiApplication.kt)
+
+```kotlin
+package com.example.whoopdavidapi
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@SpringBootApplication  // (1)
+@EnableScheduling        // (2)
+class WhoopDavidApiApplication  // (3)
+
+fun main(args: Array<String>) {   // (4)
+    runApplication<WhoopDavidApiApplication>(*args)  // (5)
+}
+```
+
+1. **`@SpringBootApplication`**: Meta-anotacion que combina tres anotaciones:
+   - `@Configuration`: Esta clase puede declarar beans (`@Bean`)
+   - `@EnableAutoConfiguration`: Spring Boot configura automaticamente beans basandose en las dependencias del classpath (si detecta JPA, configura Hibernate; si detecta H2, configura un DataSource in-memory, etc.)
+   - `@ComponentScan`: Escanea todos los paquetes bajo `com.example.whoopdavidapi` buscando clases anotadas con `@Component`, `@Service`, `@Controller`, `@Repository`, `@Configuration`
+
+2. **`@EnableScheduling`**: Activa el soporte para `@Scheduled`. Sin esta anotacion, `WhoopDataSyncScheduler` no ejecutaria su tarea cron
+
+3. **La clase esta vacia**: En Kotlin, la clase solo sirve como ancla para las anotaciones. Spring Boot no necesita que tenga metodos
+
+4. **`fun main`**: Funcion de nivel superior (top-level function). En Kotlin no necesita estar dentro de una clase
+
+5. **`runApplication<WhoopDavidApiApplication>(*args)`**: Funcion de extension de Kotlin que equivale a `SpringApplication.run(WhoopDavidApiApplication::class.java, *args)`. El `*args` es el operador spread de Kotlin que convierte un `Array` en varargs
+
+### Arquitectura de seguridad multi-cadena
+
+**Archivo**: [`src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt`](../src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt)
+
+Spring Security permite definir multiples `SecurityFilterChain`, cada una con su propio patron de URLs y reglas. El `@Order` determina la prioridad:
+
+```kotlin
+@Bean @Order(1)  // API: Basic Auth, stateless
+fun apiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http.securityMatcher("/api/**")
+        .httpBasic { }
+    // ...
+}
+
+@Bean @Order(2)  // OAuth2: flujo de autorizacion con Whoop
+fun oauth2SecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http.securityMatcher("/login/**", "/oauth2/**")
+        .oauth2Login { }
+    // ...
+}
+
+@Bean @Order(3)  // Publico: actuator, H2 console, Swagger, mock
+fun publicSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http.securityMatcher("/actuator/**", "/h2-console/**", "/mock/**",
+                         "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+        .authorizeHttpRequests { it.anyRequest().permitAll() }
+    // ...
+}
+
+@Bean @Order(4)  // Catch-all: denegar todo lo demas
+fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http.authorizeHttpRequests { it.anyRequest().denyAll() }
+    // ...
+}
+```
+
+Cuando llega una peticion, Spring evalua las cadenas en orden de `@Order`. La primera cuyo `securityMatcher` coincida con la URL es la que se aplica. Si ninguna coincide, la cadena catch-all (`@Order(4)`) deniega el acceso.
+
+### Flujo de sincronizacion
+
+**Archivo**: [`src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt)
+
+```kotlin
+@Service
+class WhoopSyncService(
+    private val whoopApiClient: WhoopApiClient,
+    private val cycleRepository: CycleRepository,
+    private val recoveryRepository: RecoveryRepository,
+    private val sleepRepository: SleepRepository,
+    private val workoutRepository: WorkoutRepository
+) {
+    fun syncAll() {
+        log.info("Iniciando sincronizacion completa con Whoop API...")
+        val start = System.currentTimeMillis()
+        syncCycles()       // 1. Sincronizar ciclos
+        syncRecoveries()   // 2. Sincronizar recuperaciones
+        syncSleeps()       // 3. Sincronizar sueno
+        syncWorkouts()     // 4. Sincronizar entrenamientos
+        val elapsed = System.currentTimeMillis() - start
+        log.info("Sincronizacion completa en {} ms", elapsed)
+    }
+}
+```
+
+El servicio inyecta el `WhoopApiClient` (para hablar con Whoop) y los 4 repositorios (para guardar en BD). La sincronizacion es secuencial porque cada tipo de dato es independiente pero compartimos la misma conexion a Whoop.
+
+### Flujo de tokens OAuth2
+
+**Archivo**: [`src/main/kotlin/com/example/whoopdavidapi/client/WhoopTokenManager.kt`](../src/main/kotlin/com/example/whoopdavidapi/client/WhoopTokenManager.kt)
+
+```kotlin
+override fun getValidAccessToken(): String {
+    val token = tokenRepository.findTopByOrderByUpdatedAtDesc()
+        ?: throw WhoopApiException("No hay token OAuth2 guardado.")
+
+    // Si el token expira en menos de 5 minutos, refrescarlo
+    if (token.expiresAt.isBefore(Instant.now().plusSeconds(300))) {
+        log.info("Access token expira pronto, refrescando...")
+        return refreshToken(token)
+    }
+
+    return token.accessToken
+        ?: throw WhoopApiException("Token OAuth2 guardado pero access_token es null.")
+}
+```
+
+Los tokens OAuth2 de Whoop se almacenan en la tabla `oauth_tokens` (cifrados con AES-256-GCM). Cada vez que el `WhoopApiClient` necesita hacer una peticion, llama a `getValidAccessToken()` que:
+
+1. Busca el token mas reciente en la BD
+2. Si expira en menos de 5 minutos, lo refresca automaticamente usando el `refresh_token`
+3. Guarda el nuevo token en la BD
+4. Devuelve el access token valido
+
+Nota la interfaz `TokenManager` en [`client/TokenManager.kt`](../src/main/kotlin/com/example/whoopdavidapi/client/TokenManager.kt) que permite sustituir la implementacion:
+
+```kotlin
+interface TokenManager {
+    fun getValidAccessToken(): String
+}
+```
+
+En el perfil `demo`, `DemoWhoopTokenManager` reemplaza a `WhoopTokenManager` devolviendo un token falso. Esto es posible gracias a `@Profile("demo")` y `@Primary` (ver [documento 11 - Perfiles](11-perfiles.md)).
+
+---
+
+## Resumen de capas
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   CONTROLLER                        │
+│  Recibe HTTP, valida params, devuelve ResponseEntity│
+│  Ejemplo: CycleController.kt                       │
+├─────────────────────────────────────────────────────┤
+│                    SERVICE                          │
+│  Logica de negocio, paginacion, transformacion      │
+│  Ejemplo: CycleService.kt, WhoopSyncService.kt     │
+├─────────────────────────────────────────────────────┤
+│                   REPOSITORY                        │
+│  Acceso a BD, derived queries, paginacion JPA       │
+│  Ejemplo: CycleRepository.kt                       │
+├─────────────────────────────────────────────────────┤
+│                    DATABASE                         │
+│  H2 (dev) / PostgreSQL (prod)                       │
+│  Tablas: whoop_cycles, whoop_recoveries, etc.       │
+└─────────────────────────────────────────────────────┘
+```
+
+**Regla fundamental**: Cada capa solo conoce a la capa inmediatamente inferior. El Controller no accede directamente al Repository; siempre pasa por el Service. Esto permite:
+
+- Testear cada capa de forma aislada (mocks)
+- Cambiar la implementacion de una capa sin afectar las demas
+- Reutilizar logica de negocio en distintos contextos (REST, scheduled, etc.)
+
+---
+
+## Documentacion oficial
+
+- [Spring Boot Application](https://docs.spring.io/spring-boot/reference/using/structuring-your-code.html)
+- [Spring Web MVC](https://docs.spring.io/spring-framework/reference/web/webmvc.html)
+- [Spring WebFlux (para comparacion)](https://docs.spring.io/spring-framework/reference/web/webflux.html)
+- [Patron BFF (Sam Newman)](https://samnewman.io/patterns/architectural/bff/)
+- [Spring Security Architecture](https://docs.spring.io/spring-security/reference/servlet/architecture.html)
+- [EnableScheduling](https://docs.spring.io/spring-framework/reference/integration/scheduling.html)

--- a/docs/02-gradle-dependencias.md
+++ b/docs/02-gradle-dependencias.md
@@ -1,0 +1,407 @@
+# 02 - Gradle y Dependencias
+
+## Que es?
+
+**Gradle** es el sistema de build (compilacion, empaquetado, tests) del proyecto. Usamos **Gradle con Kotlin DSL** (`build.gradle.kts`), lo que significa que el archivo de configuracion esta escrito en Kotlin en vez del clasico Groovy (`build.gradle`).
+
+Gradle se encarga de:
+- **Descargar dependencias** (librerias que necesita el proyecto) desde Maven Central
+- **Compilar** el codigo Kotlin a bytecode JVM
+- **Ejecutar tests** con JUnit
+- **Empaquetar** la aplicacion en un JAR ejecutable (`bootJar`)
+- **Procesar anotaciones** con kapt (para MapStruct)
+
+---
+
+## Donde se usa en este proyecto?
+
+**Archivo principal**: [`build.gradle.kts`](../build.gradle.kts)
+
+**Archivo complementario**: [`settings.gradle.kts`](../settings.gradle.kts) (solo define el nombre del proyecto raiz)
+
+```kotlin
+// settings.gradle.kts
+rootProject.name = "whoop-david-api"
+```
+
+---
+
+## Codigo explicado
+
+### Bloque de plugins
+
+```kotlin
+plugins {
+    kotlin("jvm") version "2.2.21"              // (1)
+    kotlin("plugin.spring") version "2.2.21"    // (2)
+    kotlin("plugin.jpa") version "2.2.21"       // (3)
+    kotlin("kapt") version "2.2.21"             // (4)
+    id("org.springframework.boot") version "4.0.2"     // (5)
+    id("io.spring.dependency-management") version "1.1.7"  // (6)
+}
+```
+
+1. **`kotlin("jvm")`**: Plugin base de Kotlin para JVM. Compila archivos `.kt` a bytecode Java. Sin este plugin, Gradle no sabe como compilar Kotlin
+
+2. **`kotlin("plugin.spring")`**: Alias de `kotlin-allopen` configurado para Spring. En Kotlin, todas las clases son `final` por defecto. Spring necesita crear proxies de las clases (para `@Transactional`, `@Configuration`, etc.), y los proxies requieren clases no-final. Este plugin abre automaticamente las clases anotadas con:
+   - `@Component`, `@Service`, `@Controller`, `@Repository`
+   - `@Configuration`
+   - `@Transactional`
+   - `@Async`
+   - `@Cacheable`
+
+3. **`kotlin("plugin.jpa")`**: Alias de `kotlin-noarg` configurado para JPA. Hibernate necesita constructores sin argumentos en las entidades para poder instanciarlas via reflection. Kotlin con `data class` o clases con parametros en el constructor no tiene constructor vacio por defecto. Este plugin genera constructores sin argumentos (invisibles en el codigo) para las clases anotadas con `@Entity`, `@MappedSuperclass` y `@Embeddable`
+
+4. **`kotlin("kapt")`**: **Kotlin Annotation Processing Tool**. Necesario para que MapStruct pueda generar codigo en tiempo de compilacion. kapt es el puente entre los annotation processors de Java y el compilador de Kotlin. Sin kapt, MapStruct no generaria las implementaciones de los mappers
+
+5. **`org.springframework.boot`**: El plugin de Spring Boot que agrega:
+   - Tarea `bootJar`: empaqueta la aplicacion como un fat JAR ejecutable con todas las dependencias incluidas
+   - Tarea `bootRun`: ejecuta la aplicacion directamente desde Gradle
+   - Gestion de versiones para las dependencias de Spring Boot
+
+6. **`io.spring.dependency-management`**: Gestiona las versiones de TODAS las dependencias transitivas de Spring Boot. Gracias a este plugin, cuando escribes `implementation("org.springframework.boot:spring-boot-starter-data-jpa")` no necesitas especificar la version: el plugin la resuelve automaticamente a la version compatible con Spring Boot 4.0.2
+
+### Configuracion de Java
+
+```kotlin
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(24)
+    }
+}
+```
+
+Esto configura el **Java Toolchain**: Gradle descargara y usara automaticamente Java 24 (JDK) para compilar el proyecto, independientemente de la version de Java instalada en el sistema. Esto garantiza que todos los desarrolladores y el CI usen la misma version de Java.
+
+### Repositorios
+
+```kotlin
+repositories {
+    mavenCentral()
+}
+```
+
+Las dependencias se descargan de **Maven Central**, el repositorio publico mas grande de artefactos Java/Kotlin. Es el equivalente a npm para JavaScript.
+
+---
+
+### Dependencias explicadas
+
+#### Spring Boot Starters
+
+Los **starters** son paquetes de conveniencia que agrupan varias dependencias relacionadas. En vez de agregar 15 dependencias para configurar JPA, agregas un solo starter.
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+**Que hace**: Expone endpoints de monitoreo como `/actuator/health` y `/actuator/info`.
+**Donde se usa**: Configurado en [`src/main/resources/application.yaml`](../src/main/resources/application.yaml) (lineas `management:...`). El Dockerfile lo usa para el HEALTHCHECK.
+**Si lo quitas**: No hay endpoints de monitoreo. El HEALTHCHECK del Docker fallaria. Kubernetes no podria verificar si la app esta viva.
+
+---
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+```
+**Que hace**: Incluye Spring Data JPA + Hibernate (ORM) + HikariCP (connection pool). Permite definir interfaces Repository que Spring implementa automaticamente.
+**Donde se usa**: Todas las entidades en [`model/entity/`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/) y repositorios en [`repository/`](../src/main/kotlin/com/example/whoopdavidapi/repository/).
+**Si lo quitas**: No hay acceso a base de datos. Nada funciona.
+
+---
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-security")
+```
+**Que hace**: Incluye Spring Security. Por defecto, protege TODOS los endpoints con autenticacion.
+**Donde se usa**: [`config/SecurityConfig.kt`](../src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt) - define las 4 cadenas de seguridad.
+**Si lo quitas**: La API queda completamente abierta. Cualquiera puede acceder a los datos.
+
+---
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-security-oauth2-client")
+```
+**Que hace**: Agrega soporte de cliente OAuth2. Permite que la app actue como cliente OAuth2 para autenticarse contra Whoop.
+**Donde se usa**: El flujo OAuth2 en [`config/SecurityConfig.kt`](../src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt) (`oauth2Login { }`) y la configuracion del provider en [`application.yaml`](../src/main/resources/application.yaml) (`spring.security.oauth2.client`).
+**Si lo quitas**: No puedes autenticarte contra Whoop API. No puedes obtener el token OAuth2 inicial.
+
+---
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-validation")
+```
+**Que hace**: Incluye Jakarta Bean Validation (Hibernate Validator). Permite validar parametros con anotaciones como `@NotNull`, `@Size`, etc.
+**Donde se usa**: Validaciones con `require()` en los controladores, por ejemplo en [`controller/CycleController.kt`](../src/main/kotlin/com/example/whoopdavidapi/controller/CycleController.kt):
+```kotlin
+require(page >= 1) { "page debe ser >= 1" }
+require(pageSize in 1..1000) { "pageSize debe estar entre 1 y 1000" }
+```
+**Si lo quitas**: Las validaciones manuales con `require()` siguen funcionando (son de Kotlin), pero pierdes la infraestructura de `@Valid` y `@Validated` si las necesitas en el futuro.
+
+---
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-webmvc")
+```
+**Que hace**: Incluye Spring Web MVC + Tomcat embebido. Es el nucleo del servidor web.
+**Donde se usa**: Todos los controladores en [`controller/`](../src/main/kotlin/com/example/whoopdavidapi/controller/) usan `@RestController` y `@GetMapping` de WebMVC.
+**Si lo quitas**: No hay servidor web. La aplicacion no puede recibir peticiones HTTP.
+
+---
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-h2console")
+```
+**Que hace**: Habilita la consola web de H2 (interfaz grafica para ver la BD in-memory en desarrollo).
+**Donde se usa**: Configurada en [`application-dev.yaml`](../src/main/resources/application-dev.yaml) (`spring.h2.console.enabled: true`). Accesible en `http://localhost:8080/h2-console`.
+**Si lo quitas**: No puedes ver la BD H2 desde el navegador en desarrollo. La BD sigue funcionando.
+
+---
+
+#### Kotlin
+
+```kotlin
+implementation("org.jetbrains.kotlin:kotlin-reflect")
+```
+**Que hace**: Libreria de reflection de Kotlin. Spring la necesita para inspeccionar clases Kotlin en runtime (leer anotaciones, crear instancias, etc.).
+**Donde se usa**: Internamente por Spring Framework, Jackson y Hibernate.
+**Si lo quitas**: Spring no puede trabajar correctamente con clases Kotlin. Errores en runtime.
+
+---
+
+```kotlin
+implementation("tools.jackson.module:jackson-module-kotlin")
+```
+**Que hace**: Modulo de Jackson para Kotlin. Permite a Jackson serializar/deserializar `data class` de Kotlin correctamente (reconoce parametros del constructor, tipos nullable, valores por defecto, etc.).
+**Donde se usa**: Automaticamente por Spring MVC para convertir objetos a JSON en las respuestas de los controladores.
+**Si lo quitas**: Jackson no puede deserializar DTOs de Kotlin. Los endpoints devuelven errores.
+
+> **GOTCHA Spring Boot 4**: El paquete cambio de `com.fasterxml.jackson.module:jackson-module-kotlin` (Jackson 2) a `tools.jackson.module:jackson-module-kotlin` (Jackson 3). Spring Boot 4 usa **Jackson 3**, que cambio su grupo Maven de `com.fasterxml` a `tools.jackson`.
+
+---
+
+#### MapStruct
+
+```kotlin
+implementation("org.mapstruct:mapstruct:1.6.3")
+kapt("org.mapstruct:mapstruct-processor:1.6.3")
+```
+**Que hace**: MapStruct genera automaticamente el codigo de mapeo entre Entity y DTO en tiempo de compilacion. `mapstruct` es la libreria de anotaciones. `mapstruct-processor` es el annotation processor que genera las implementaciones.
+**Donde se usa**: Los 4 mappers en [`mapper/`](../src/main/kotlin/com/example/whoopdavidapi/mapper/). Por ejemplo, [`mapper/CycleMapper.kt`](../src/main/kotlin/com/example/whoopdavidapi/mapper/CycleMapper.kt):
+```kotlin
+@Mapper(componentModel = "spring")
+interface CycleMapper {
+    fun toDto(entity: WhoopCycle): CycleDTO
+    fun toEntity(dto: CycleDTO): WhoopCycle
+}
+```
+MapStruct genera automaticamente una clase `CycleMapperImpl` con el codigo de mapeo campo por campo.
+**Si lo quitas**: Necesitas escribir el mapeo a mano en cada servicio. Con 4 entidades y muchos campos, es mucho codigo repetitivo.
+
+---
+
+#### Resilience4j
+
+```kotlin
+implementation("io.github.resilience4j:resilience4j-spring-boot3:2.3.0")
+implementation("org.springframework.boot:spring-boot-starter-aspectj")
+```
+**Que hace**: Resilience4j proporciona patrones de resiliencia (circuit breaker, retry, rate limiter) via anotaciones. El starter de AspectJ es necesario porque Resilience4j usa AOP (Aspect-Oriented Programming) para interceptar llamadas a metodos anotados.
+**Donde se usa**: [`client/WhoopApiClient.kt`](../src/main/kotlin/com/example/whoopdavidapi/client/WhoopApiClient.kt) - cada metodo tiene `@CircuitBreaker`, `@Retry` y `@RateLimiter`:
+```kotlin
+@CircuitBreaker(name = "whoopApi", fallbackMethod = "fallbackGetAllRecords")
+@Retry(name = "whoopApi")
+@RateLimiter(name = "whoopApi")
+fun getAllCycles(start: Instant? = null, end: Instant? = null): List<Map<String, Any?>> {
+    return getAllRecords("/developer/v1/cycle", start, end)
+}
+```
+Configurado en [`application.yaml`](../src/main/resources/application.yaml) (seccion `resilience4j:`).
+**Si quitas resilience4j**: Los errores de Whoop API se propagan directamente. No hay reintentos ni circuit breaker. La sincronizacion falla completamente si Whoop tiene problemas temporales.
+**Si quitas starter-aspectj**: Las anotaciones de Resilience4j se ignoran silenciosamente. El codigo se ejecuta pero sin proteccion.
+
+> **GOTCHA Spring Boot 4**: El starter se renombro de `spring-boot-starter-aop` a `spring-boot-starter-aspectj`. Si usas el nombre antiguo, Gradle no lo encuentra.
+
+---
+
+#### OpenAPI / Swagger UI
+
+```kotlin
+implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
+```
+**Que hace**: Genera automaticamente documentacion OpenAPI 3.0 a partir de los controladores y la expone en Swagger UI.
+**Donde se usa**: Configurado en [`config/OpenApiConfig.kt`](../src/main/kotlin/com/example/whoopdavidapi/config/OpenApiConfig.kt) y [`application.yaml`](../src/main/resources/application.yaml) (seccion `springdoc:`). Swagger UI accesible en `/swagger-ui/index.html`.
+**Si lo quitas**: No hay Swagger UI ni documentacion automatica de la API.
+
+> **GOTCHA Spring Boot 4**: springdoc-openapi **v3.x** es para Spring Boot 4. La version **v2.x** es para Spring Boot 3. Si usas v2.x con Spring Boot 4, falla por incompatibilidades con Jackson 3.
+
+---
+
+#### Base de datos
+
+```kotlin
+runtimeOnly("com.h2database:h2")
+runtimeOnly("org.postgresql:postgresql")
+```
+**Que hacen**: Drivers JDBC para H2 (BD in-memory) y PostgreSQL. `runtimeOnly` significa que solo se necesitan en runtime, no en compilacion.
+**Donde se usan**:
+- H2: [`application-dev.yaml`](../src/main/resources/application-dev.yaml) - perfil de desarrollo
+- PostgreSQL: [`application-prod.yaml`](../src/main/resources/application-prod.yaml) - perfil de produccion
+**Si quitas H2**: El perfil `dev` no funciona (no tiene BD)
+**Si quitas PostgreSQL**: El perfil `prod` no funciona (no puede conectar a la BD)
+
+---
+
+#### Test
+
+```kotlin
+testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")
+testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+testImplementation("org.springframework.boot:spring-boot-starter-security-test")
+testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+```
+
+| Dependencia | Que proporciona |
+|---|---|
+| `actuator-test` | Utilidades para testear actuator |
+| `data-jpa-test` | `@DataJpaTest` para tests de repositorio con BD embebida |
+| `security-test` | `httpBasic()`, `csrf()` y otras utilidades para testear seguridad |
+| `webmvc-test` | `MockMvc`, `@WebMvcTest`, `@AutoConfigureMockMvc` |
+| `kotlin-test-junit5` | Assertions de Kotlin + integracion con JUnit 5 |
+| `junit-platform-launcher` | Ejecutor de tests JUnit 5 |
+
+> **GOTCHA Spring Boot 4**: Los paquetes de las anotaciones de test cambiaron:
+> - `@WebMvcTest` esta ahora en `org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest`
+> - `@DataJpaTest` esta ahora en `org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest`
+> - `@AutoConfigureMockMvc` esta ahora en `org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc`
+> - `@MockBean` fue reemplazado por `@MockitoBean` de `org.springframework.test.context.bean.override.mockito.MockitoBean`
+
+---
+
+### Configuracion de kapt
+
+```kotlin
+kapt {
+    correctErrorTypes = true      // (1)
+    includeCompileClasspath = false  // (2)
+    arguments {
+        arg("mapstruct.defaultComponentModel", "spring")  // (3)
+    }
+}
+```
+
+1. **`correctErrorTypes = true`**: Corrige errores de tipos cuando kapt no puede resolver una referencia. Necesario para que kapt funcione bien con Kotlin
+2. **`includeCompileClasspath = false`**: Evita que kapt procese todo el classpath de compilacion (mejor rendimiento)
+3. **`mapstruct.defaultComponentModel = "spring"`**: Le dice a MapStruct que genere los mappers como beans de Spring (`@Component`). Asi pueden inyectarse con `@Autowired` o por constructor
+
+---
+
+### Desactivar kapt para tests
+
+```kotlin
+// Desactivar kapt para test sources (no hay annotation processors en tests)
+tasks.matching { it.name == "kaptTestKotlin" || it.name == "kaptGenerateStubsTestKotlin" }.configureEach {
+    enabled = false
+}
+```
+
+> **GOTCHA Spring Boot 4**: kapt intenta procesar las anotaciones de test (`@DataJpaTest`, `@WebMvcTest`, etc.) de Spring Boot 4 y falla porque estas anotaciones cambiaron de paquete. Como no hay annotation processors necesarios en los tests, desactivamos kapt para tests completamente.
+
+Sin esta linea, la compilacion de tests falla con errores de kapt al intentar resolver las nuevas anotaciones de Spring Boot 4.
+
+---
+
+### Opciones del compilador Kotlin
+
+```kotlin
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
+    }
+}
+```
+
+- **`-Xjsr305=strict`**: Hace que Kotlin trate las anotaciones de nulabilidad de Java (`@Nullable`, `@NonNull` de JSR-305) como estrictas. Esto significa que si una API de Spring declara un parametro como `@NonNull`, Kotlin lo trata como no-nullable (`String` en vez de `String?`). Mejora la seguridad de tipos en la interoperabilidad Kotlin/Java.
+
+- **`-Xannotation-default-target=param-property`**: Controla donde se colocan las anotaciones en las propiedades de Kotlin. Por defecto en constructores de Kotlin, una anotacion como `@Column` podria aplicarse al parametro del constructor en vez de al campo. Con esta opcion, se aplica tanto al parametro como a la propiedad, lo que es necesario para que JPA/Hibernate las detecte correctamente.
+
+---
+
+### Plugin allOpen para JPA
+
+```kotlin
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
+}
+```
+
+Como se menciono, en Kotlin todas las clases son `final` por defecto. Hibernate necesita crear proxies (subclases) de las entidades para funcionalidades como lazy loading. Las clases `final` no pueden tener subclases.
+
+El bloque `allOpen` complementa al plugin `kotlin("plugin.jpa")`:
+- `plugin.jpa` genera constructores sin argumentos
+- `allOpen` abre las clases (las hace no-final)
+
+Ambos son necesarios para que JPA/Hibernate funcione correctamente con Kotlin.
+
+**Ejemplo concreto**: La entidad `WhoopCycle` en [`model/entity/WhoopCycle.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/WhoopCycle.kt):
+
+```kotlin
+@Entity
+@Table(name = "whoop_cycles")
+class WhoopCycle(
+    @Id
+    @Column(name = "id")
+    var id: Long = 0,
+    // ...
+)
+```
+
+Gracias a `allOpen`, esta clase se compila como `open class WhoopCycle` en vez de `final class WhoopCycle`, permitiendo que Hibernate cree proxies.
+
+---
+
+### Configuracion de tests
+
+```kotlin
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+```
+
+Configura Gradle para usar JUnit Platform (JUnit 5) como motor de ejecucion de tests. Sin esta linea, Gradle usa JUnit 4 por defecto y no encuentra los tests anotados con `@Test` de JUnit 5.
+
+---
+
+## Por que esta decision?
+
+### Por que Gradle Kotlin DSL y no Groovy?
+
+- **Type-safety**: El IDE puede verificar errores en el build script en tiempo de escritura
+- **Autocompletado**: IntelliJ IDEA puede sugerir metodos y propiedades
+- **Coherencia**: Todo el proyecto esta en Kotlin, incluyendo el build script
+
+### Por que kapt y no KSP para MapStruct?
+
+**KSP** (Kotlin Symbol Processing) es mas rapido que kapt, pero MapStruct 1.6.3 aun no tiene soporte oficial para KSP. Usar kapt es la unica opcion funcional actualmente.
+
+### Por que las versiones de los plugins de Kotlin deben coincidir?
+
+Todos los plugins de Kotlin (`jvm`, `plugin.spring`, `plugin.jpa`, `kapt`) deben tener la **misma version** (2.2.21). Si difieren, el compilador de Kotlin puede producir errores o comportamientos inesperados.
+
+---
+
+## Documentacion oficial
+
+- [Gradle Kotlin DSL Primer](https://docs.gradle.org/current/userguide/kotlin_dsl.html)
+- [Spring Boot Gradle Plugin](https://docs.spring.io/spring-boot/gradle-plugin/)
+- [Kotlin Gradle Plugin](https://kotlinlang.org/docs/gradle-configure-project.html)
+- [kapt (Kotlin Annotation Processing)](https://kotlinlang.org/docs/kapt.html)
+- [allOpen Compiler Plugin](https://kotlinlang.org/docs/all-open-plugin.html)
+- [No-arg Compiler Plugin](https://kotlinlang.org/docs/no-arg-plugin.html)
+- [MapStruct Reference](https://mapstruct.org/documentation/stable/reference/html/)
+- [Spring Boot Dependency Management](https://docs.spring.io/spring-boot/gradle-plugin/managing-dependencies.html)
+- [Java Toolchains in Gradle](https://docs.gradle.org/current/userguide/toolchains.html)

--- a/docs/03-entidades-jpa.md
+++ b/docs/03-entidades-jpa.md
@@ -1,0 +1,462 @@
+# 03 - Entidades JPA
+
+> Capa de persistencia: como las clases Kotlin se convierten en tablas de PostgreSQL.
+
+---
+
+## 1. Que es JPA y Hibernate?
+
+**JPA (Jakarta Persistence API)** es una **especificacion** (un contrato, como una interfaz) que define como las aplicaciones Java/Kotlin deben interactuar con bases de datos relacionales usando objetos. JPA **no es una libreria** que ejecutas directamente: es un conjunto de anotaciones (`@Entity`, `@Table`, `@Column`...) y reglas que cualquier implementacion debe seguir.
+
+**Hibernate** es la **implementacion** mas popular de JPA. Cuando Spring Boot arranca con `spring-boot-starter-data-jpa`, automaticamente incluye Hibernate como motor ORM (Object-Relational Mapping). Es Hibernate quien realmente genera las sentencias SQL, gestiona el cache de entidades, y traduce objetos Kotlin a filas de base de datos.
+
+```
+Tu codigo Kotlin  --->  JPA (anotaciones)  --->  Hibernate (implementacion)  --->  SQL  --->  PostgreSQL
+```
+
+**Analogia**: JPA es como una interfaz de Java, e Hibernate es la clase que la implementa. Tu codigo solo usa la interfaz (anotaciones de `jakarta.persistence.*`), nunca importas nada de Hibernate directamente. Esto te da la libertad teorica de cambiar de implementacion sin modificar tus entidades.
+
+### Donde se configura en este proyecto?
+
+La dependencia esta en [`build.gradle.kts`](../build.gradle.kts), linea 27:
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+```
+
+Este starter incluye automaticamente:
+- **Hibernate 7** (la version compatible con Spring Boot 4.0.2)
+- **Spring Data JPA** (repositorios, etc.)
+- **Jakarta Persistence API** (las anotaciones `@Entity`, `@Column`, etc.)
+- **HikariCP** (pool de conexiones a la base de datos)
+
+---
+
+## 2. Donde se usa en este proyecto?
+
+Las entidades JPA estan en el paquete `model.entity`:
+
+| Archivo | Tabla en BD | ID | Tipo de ID |
+|---------|-------------|-----|-----------|
+| [`src/main/kotlin/.../model/entity/WhoopCycle.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/WhoopCycle.kt) | `whoop_cycles` | `id: Long` | Del Whoop API |
+| [`src/main/kotlin/.../model/entity/WhoopRecovery.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/WhoopRecovery.kt) | `whoop_recoveries` | `cycleId: Long` | Del Whoop API |
+| [`src/main/kotlin/.../model/entity/WhoopSleep.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/WhoopSleep.kt) | `whoop_sleeps` | `id: String` | Del Whoop API |
+| [`src/main/kotlin/.../model/entity/WhoopWorkout.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/WhoopWorkout.kt) | `whoop_workouts` | `id: String` | Del Whoop API |
+| [`src/main/kotlin/.../model/entity/OAuthTokenEntity.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/OAuthTokenEntity.kt) | `oauth_tokens` | `id: Long?` | Auto-generado por BD |
+
+---
+
+## 3. Por que esta decision?
+
+### 3a. Por que JPA y no JDBC directo o jOOQ?
+
+- **Productividad**: Con JPA, no escribes SQL manualmente para operaciones CRUD. Defines una clase y JPA genera la tabla y las queries.
+- **Patron BFF de un solo usuario**: Este proyecto sincroniza datos de un solo usuario de Whoop. Las queries son simples (filtros por fecha, paginacion). No necesitamos la flexibilidad de SQL raw que ofrece jOOQ.
+- **Ecosistema Spring**: Spring Data JPA se integra nativamente con Spring Boot. Los repositorios, la transaccionalidad y la paginacion funcionan "out of the box".
+
+### 3b. Por que `class` y no `data class` para entidades?
+
+Las entidades JPA usan `class` (no `data class`) por tres razones:
+
+1. **Proxies de Hibernate**: Hibernate necesita crear proxies (subclases) de tus entidades para lazy loading y dirty checking. Las `data class` generan `equals()`, `hashCode()` y `copy()` basados en **todos** los campos del constructor, lo cual interfiere con el mecanismo de proxies.
+2. **Identidad vs igualdad**: Dos objetos `WhoopCycle` con el mismo `id` deben ser "la misma entidad" aunque otros campos difieran (Hibernate puede tener la version parcialmente cargada). El `equals()` de `data class` fallaria en esos casos.
+3. **Mutabilidad**: JPA necesita `var` (mutables) para poder setear valores al cargar de BD. Las `data class` funcionan mejor con `val` (inmutables).
+
+### 3c. Por que campos `var` con valores por defecto?
+
+```kotlin
+var id: Long = 0,           // Valor por defecto: 0
+var scoreState: String = "PENDING_SCORE",  // Valor por defecto: string
+var end: Instant? = null,   // Valor por defecto: null (nullable)
+```
+
+JPA/Hibernate requiere un **constructor sin argumentos** para poder instanciar entidades al cargarlas desde la BD. En Kotlin, al dar valores por defecto a **todos** los parametros del constructor primario, el compilador genera automaticamente un constructor sin argumentos. Esto evita tener que escribir un constructor secundario vacio.
+
+---
+
+## 4. Codigo explicado
+
+### 4a. Anotaciones basicas: `@Entity`, `@Table`, `@Id`, `@Column`
+
+Vamos a analizar [`WhoopCycle.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/WhoopCycle.kt):
+
+```kotlin
+package com.example.whoopdavidapi.model.entity
+
+import jakarta.persistence.*       // Todas las anotaciones JPA
+import java.time.Instant            // Tipo de timestamp timezone-safe
+
+@Entity                              // (1) Marca esta clase como entidad JPA
+@Table(name = "whoop_cycles")       // (2) Nombre de la tabla en la BD
+class WhoopCycle(
+    @Id                              // (3) Este campo es la clave primaria
+    @Column(name = "id")             // (4) Nombre de la columna en la tabla
+    var id: Long = 0,
+
+    @Column(name = "user_id", nullable = false)  // (5) NOT NULL en la BD
+    var userId: Long = 0,
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null,  // (6) Nullable en Kotlin = nullable en BD
+
+    @Column(name = "updated_at")
+    var updatedAt: Instant? = null,
+
+    @Column(name = "start_time", nullable = false)
+    var start: Instant = Instant.now(),
+
+    @Column(name = "end_time")
+    var end: Instant? = null,
+
+    @Column(name = "timezone_offset")
+    var timezoneOffset: String? = null,
+
+    @Column(name = "score_state", nullable = false)
+    var scoreState: String = "PENDING_SCORE",
+
+    // Score fields (flattened)      // (7) Campos "aplanados"
+    @Column(name = "strain")
+    var strain: Float? = null,
+
+    @Column(name = "kilojoule")
+    var kilojoule: Float? = null,
+
+    @Column(name = "average_heart_rate")
+    var averageHeartRate: Int? = null,
+
+    @Column(name = "max_heart_rate")
+    var maxHeartRate: Int? = null
+)
+```
+
+**Explicacion linea por linea**:
+
+| # | Anotacion/Concepto | Que hace |
+|---|---------------------|----------|
+| (1) | `@Entity` | Le dice a JPA: "esta clase representa una tabla en la BD". Sin esta anotacion, Hibernate la ignora completamente. |
+| (2) | `@Table(name = "whoop_cycles")` | Especifica el nombre exacto de la tabla. Sin ella, JPA usaria el nombre de la clase (`WhoopCycle` -> `whoop_cycle`). Lo ponemos explicitamente para claridad. |
+| (3) | `@Id` | Marca el campo como **clave primaria**. Toda entidad JPA **debe** tener exactamente un `@Id`. |
+| (4) | `@Column(name = "id")` | Mapea la propiedad Kotlin al nombre de columna en SQL. Cuando el nombre de la propiedad y la columna coinciden, es opcional, pero lo incluimos para ser explicitos. |
+| (5) | `nullable = false` | Genera `NOT NULL` en el DDL. Hibernate lanzara una excepcion si intentas guardar un `null` en ese campo. |
+| (6) | `Instant?` (nullable en Kotlin) | Los campos con `?` pueden ser `null`. Esto se alinea con la BD: `createdAt` puede no existir si el dato aun no ha sido procesado por Whoop. |
+| (7) | Score fields (flattened) | Ver seccion 4c mas abajo. |
+
+### 4b. Estrategia de IDs: por que difiere entre entidades
+
+Este es un punto clave de diseno. Hay **dos estrategias** distintas:
+
+#### Estrategia 1: ID asignado por Whoop API (WhoopCycle, WhoopRecovery, WhoopSleep, WhoopWorkout)
+
+```kotlin
+// WhoopCycle.kt
+@Id
+@Column(name = "id")
+var id: Long = 0           // SIN @GeneratedValue --> el ID lo asignamos nosotros
+```
+
+```kotlin
+// WhoopRecovery.kt
+@Id
+@Column(name = "cycle_id")
+var cycleId: Long = 0      // El ID de recovery ES el cycle_id de Whoop
+```
+
+```kotlin
+// WhoopSleep.kt
+@Id
+@Column(name = "id")
+var id: String = ""         // El ID de sleep es un String (UUID de Whoop)
+```
+
+**Por que?** Estos datos vienen de la Whoop API v2 con su propio identificador unico. Usamos ese mismo ID como clave primaria en nuestra BD por dos razones:
+
+1. **Idempotencia en la sincronizacion**: Cuando el scheduler ejecuta `repository.save(cycle)`, si el `id` ya existe, JPA hace un `UPDATE` en vez de un `INSERT`. Esto significa que podemos re-sincronizar datos sin crear duplicados.
+2. **Trazabilidad**: Si necesitas debuggear, puedes buscar el mismo ID en nuestra BD y en la API de Whoop.
+
+Nota que **WhoopSleep** y **WhoopWorkout** usan `String` como tipo de ID (son UUIDs en la API de Whoop), mientras que **WhoopCycle** y **WhoopRecovery** usan `Long`.
+
+#### Estrategia 2: ID auto-generado por la BD (OAuthTokenEntity)
+
+```kotlin
+// OAuthTokenEntity.kt
+@Id
+@GeneratedValue(strategy = GenerationType.IDENTITY)
+var id: Long? = null        // (A) Nullable porque aun no existe hasta el INSERT
+```
+
+**`@GeneratedValue(strategy = GenerationType.IDENTITY)`**: Le dice a JPA que la base de datos se encarga de generar el ID. En PostgreSQL, esto usa una columna `BIGSERIAL` (auto-increment). En H2 (desarrollo), usa `IDENTITY`.
+
+**Por que `Long?` (nullable)?** Cuando creas un `OAuthTokenEntity` nuevo, aun no tiene ID:
+
+```kotlin
+val token = OAuthTokenEntity(
+    accessToken = "eyJhbG...",  // id es null aqui
+    refreshToken = "dGhpcw...",
+    expiresAt = Instant.now().plusSeconds(3600)
+)
+oAuthTokenRepository.save(token)  // Ahora id tiene valor (ej: 1, 2, 3...)
+```
+
+**Por que esta entidad SI auto-genera y las demas NO?** Los tokens OAuth no vienen de la Whoop API con un ID propio. Son datos internos de nuestra aplicacion. La BD decide el ID.
+
+### 4c. Diseno "aplanado" (flattened): por que no hay tablas separadas para scores
+
+La Whoop API v2 devuelve datos anidados. Por ejemplo, un cycle tiene:
+
+```json
+{
+  "id": 12345,
+  "user_id": 67890,
+  "start": "2024-01-15T08:00:00Z",
+  "score_state": "SCORED",
+  "score": {
+    "strain": 15.5,
+    "kilojoule": 2500.0,
+    "average_heart_rate": 72,
+    "max_heart_rate": 185
+  }
+}
+```
+
+En un diseno relacional "puro", harias dos tablas: `whoop_cycles` y `whoop_cycle_scores`, con una relacion `@OneToOne`. Nosotros **aplanamos** esos campos directamente en la entidad:
+
+```kotlin
+// En vez de @OneToOne a una tabla CycleScore:
+@Column(name = "strain")
+var strain: Float? = null,          // score.strain  -> columna directa
+
+@Column(name = "kilojoule")
+var kilojoule: Float? = null,       // score.kilojoule  -> columna directa
+
+@Column(name = "average_heart_rate")
+var averageHeartRate: Int? = null,   // score.average_heart_rate  -> columna directa
+
+@Column(name = "max_heart_rate")
+var maxHeartRate: Int? = null        // score.max_heart_rate  -> columna directa
+```
+
+**Por que aplanar?**
+
+1. **Simplicidad**: Este es un proyecto BFF para un solo usuario. No hay millones de filas ni consultas complejas. Una tabla plana es mas facil de consultar en Power BI.
+2. **Rendimiento**: Un `JOIN` menos en cada query. En Power BI, conectas una sola tabla y tienes todos los datos.
+3. **Mantenimiento**: Menos entidades, menos repositorios, menos mappers. El codigo es mas facil de entender.
+4. **Relacion 1:1 estricta**: Un cycle tiene **exactamente** un score (o ninguno si esta `PENDING_SCORE`). No hay relacion 1:N que justifique una tabla separada.
+
+Los campos de score son `nullable` (`Float?`, `Int?`) porque cuando `scoreState = "PENDING_SCORE"`, aun no hay datos de score.
+
+Observa como esto se aplica en todas las entidades:
+
+- **WhoopSleep**: Aplana `stage_summary` (8 campos como `totalInBedTimeMilli`, `totalRemSleepTimeMilli`) y `sleep_needed` (4 campos como `baselineMilli`, `needFromSleepDebtMilli`) directamente en la tabla.
+- **WhoopWorkout**: Aplana `score` (8 campos) y `zone_duration` (6 campos: `zoneZeroMilli` a `zoneFiveMilli`) directamente.
+- **WhoopRecovery**: Aplana `score` (6 campos: `recoveryScore`, `restingHeartRate`, `hrvRmssdMilli`, etc.).
+
+### 4d. `@Convert` y cifrado de tokens: `EncryptedStringConverter` y `TokenEncryptor`
+
+Los tokens OAuth2 son **datos sensibles**. Si alguien accede a la BD, no deberia poder leer el `accessToken` ni el `refreshToken` en texto plano. JPA ofrece `@Convert` para transformar datos automaticamente al leer y escribir.
+
+En [`OAuthTokenEntity.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/entity/OAuthTokenEntity.kt):
+
+```kotlin
+@Column(name = "access_token", length = 4096)
+@Convert(converter = EncryptedStringConverter::class)
+var accessToken: String? = null,
+
+@Column(name = "refresh_token", length = 4096)
+@Convert(converter = EncryptedStringConverter::class)
+var refreshToken: String? = null,
+```
+
+**`length = 4096`**: Los tokens cifrados ocupan mas espacio que los originales. El calculo es:
+- Token original: ~2KB max
+- IV (12 bytes) + ciphertext + GCM tag (16 bytes) = ~2.028KB
+- Base64 encoding agrega 33% overhead = ~2.7KB
+- Margen de seguridad = 4096 bytes total
+
+**`@Convert(converter = EncryptedStringConverter::class)`**: Cada vez que JPA guarda o lee este campo, pasa por el converter.
+
+El converter esta en [`src/main/kotlin/.../util/EncryptedStringConverter.kt`](../src/main/kotlin/com/example/whoopdavidapi/util/EncryptedStringConverter.kt):
+
+```kotlin
+@Converter                                                 // (1) Anotacion JPA
+@Component                                                 // (2) Bean de Spring
+class EncryptedStringConverter(
+    private val encryptor: TokenEncryptor                   // (3) Inyeccion de dependencia
+) : AttributeConverter<String?, String?> {                 // (4) Interface JPA
+
+    override fun convertToDatabaseColumn(attribute: String?): String? {
+        return encryptor.encrypt(attribute)                 // (5) Kotlin -> BD: cifra
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): String? {
+        return encryptor.decrypt(dbData)                    // (6) BD -> Kotlin: descifra
+    }
+}
+```
+
+| # | Que hace |
+|---|----------|
+| (1) | `@Converter` marca esta clase como converter JPA. |
+| (2) | `@Component` la registra como bean de Spring, necesario para que la inyeccion de `TokenEncryptor` funcione. |
+| (3) | `TokenEncryptor` es otro componente Spring que contiene la logica real de cifrado. |
+| (4) | `AttributeConverter<String?, String?>` es la interfaz JPA: transforma `String?` (tipo Kotlin) a `String?` (tipo BD). |
+| (5) | Al hacer `repository.save(entity)`, JPA llama a `convertToDatabaseColumn`. El token en claro se cifra antes de llegar a la BD. |
+| (6) | Al hacer `repository.findById(id)`, JPA llama a `convertToEntityAttribute`. El texto cifrado se descifra antes de llegar a tu codigo. |
+
+**Flujo completo**:
+
+```
+Tu codigo: token.accessToken = "eyJhbGci..."
+    |
+    v  convertToDatabaseColumn()
+    |
+BD almacena: "Rk3mX2p...base64...cifrado..."
+    |
+    v  convertToEntityAttribute()
+    |
+Tu codigo recibe: "eyJhbGci..."  (transparente)
+```
+
+El cifrado real lo hace [`src/main/kotlin/.../util/TokenEncryptor.kt`](../src/main/kotlin/com/example/whoopdavidapi/util/TokenEncryptor.kt), que usa **AES-256-GCM**:
+
+```kotlin
+@Component
+class TokenEncryptor(
+    @Value("\${app.security.encryption-key:#{null}}") private val encryptionKey: String?
+) {
+    private val algorithm = "AES/GCM/NoPadding"
+    private val keySpec: SecretKeySpec
+    private val secureRandom = SecureRandom()
+
+    companion object {
+        private const val GCM_IV_LENGTH = 12    // 96 bits, recomendado para GCM
+        private const val GCM_TAG_LENGTH = 128  // 128 bits, tag de autenticacion
+    }
+
+    init {
+        // Falla al arrancar si no hay clave configurada
+        require(!encryptionKey.isNullOrBlank()) {
+            "app.security.encryption-key debe estar configurada."
+        }
+
+        // Decodifica la clave desde Base64
+        val keyBytes = Base64.getDecoder().decode(encryptionKey)
+
+        // Valida que sean exactamente 32 bytes (256 bits)
+        require(keyBytes.size == 32) {
+            "La clave debe representar exactamente 32 bytes (256 bits)."
+        }
+
+        keySpec = SecretKeySpec(keyBytes, "AES")
+    }
+
+    fun encrypt(plainText: String?): String? {
+        if (plainText == null) return null
+        val cipher = Cipher.getInstance(algorithm)
+        val iv = ByteArray(GCM_IV_LENGTH)
+        secureRandom.nextBytes(iv)                          // IV aleatorio cada vez
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec)
+        val encryptedBytes = cipher.doFinal(plainText.toByteArray(Charsets.UTF_8))
+        val combined = iv + encryptedBytes                  // IV + ciphertext + GCM tag
+        return Base64.getEncoder().encodeToString(combined)
+    }
+
+    fun decrypt(encryptedText: String?): String? {
+        if (encryptedText == null) return null
+        val combined = Base64.getDecoder().decode(encryptedText)
+        val iv = combined.take(GCM_IV_LENGTH).toByteArray()
+        val ciphertext = combined.drop(GCM_IV_LENGTH).toByteArray()
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+        val cipher = Cipher.getInstance(algorithm)
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmSpec)
+        return String(cipher.doFinal(ciphertext), Charsets.UTF_8)
+    }
+}
+```
+
+**Conceptos clave de AES-256-GCM**:
+
+- **AES-256**: Algoritmo de cifrado simetrico con clave de 256 bits. "Simetrico" = la misma clave cifra y descifra.
+- **GCM (Galois/Counter Mode)**: Modo de operacion que proporciona **confidencialidad** (nadie puede leer el texto) Y **autenticidad** (nadie puede modificar el texto cifrado sin que lo detectemos). El "tag" de 128 bits es como una firma digital del contenido cifrado.
+- **IV (Initialization Vector)**: 12 bytes aleatorios que se generan para **cada operacion de cifrado**. Esto garantiza que cifrar el mismo texto dos veces produce resultados distintos. El IV se almacena junto con el texto cifrado (no es secreto).
+- **NoPadding**: GCM no necesita padding (a diferencia de CBC), lo que simplifica la implementacion.
+
+**Por que la clave viene de `application.yaml` y no esta hardcodeada?** La propiedad `app.security.encryption-key` se configura como variable de entorno o secreto de Kubernetes. Nunca se commitea al repositorio.
+
+### 4e. El plugin `allOpen` y por que es necesario en Kotlin
+
+En Kotlin, **todas las clases son `final` por defecto**. Esto significa que no se pueden heredar (no puedes hacer `class Hijo : WhoopCycle()`). Pero Hibernate necesita crear **proxies** de tus entidades, y los proxies son subclases.
+
+El plugin `kotlin("plugin.jpa")` (que incluye `allOpen`) resuelve esto. En [`build.gradle.kts`](../build.gradle.kts):
+
+```kotlin
+plugins {
+    kotlin("plugin.jpa") version "2.2.21"    // (1) Incluye allOpen para JPA
+}
+
+// ...
+
+allOpen {                                     // (2) Configuracion explicita
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
+}
+```
+
+**Que hace esto?** Cuando el compilador de Kotlin encuentra una clase con `@Entity`, `@MappedSuperclass` o `@Embeddable`, automaticamente la hace `open` (no final). Asi:
+
+```kotlin
+// Lo que TU escribes:
+@Entity
+class WhoopCycle(...)
+
+// Lo que el COMPILADOR genera (gracias a allOpen):
+@Entity
+open class WhoopCycle(...)    // <-- ahora Hibernate puede crear proxies
+```
+
+Sin este plugin, Hibernate lanzaria un error al intentar crear proxies de clases finales, o funcionaria en modo degradado sin lazy loading.
+
+### 4f. `java.time.Instant` para timestamps: por que NO usar `Date` ni `LocalDateTime`
+
+Todas las entidades usan `java.time.Instant` para campos temporales:
+
+```kotlin
+var createdAt: Instant? = null,
+var updatedAt: Instant? = null,
+var start: Instant = Instant.now(),
+var end: Instant? = null,
+var expiresAt: Instant = Instant.now(),
+```
+
+**Por que `Instant` y no las alternativas?**
+
+| Tipo | Problema | Zona horaria? |
+|------|----------|---------------|
+| `java.util.Date` | API legacy llena de bugs, mutable, no thread-safe. Deprecada en la practica. | Internamente UTC, pero la API es confusa. |
+| `LocalDateTime` | **No tiene zona horaria**. `2024-01-15T08:00:00` puede ser las 8 AM en Madrid o en Tokyo. Peligroso para datos que cruzan zonas horarias. | NO |
+| `OffsetDateTime` | Buena opcion, pero mas compleja de lo necesario para nuestro caso. | SI (offset fijo) |
+| `Instant` | Punto exacto en el tiempo, siempre UTC. Simple, inmutable, thread-safe. | SI (siempre UTC) |
+
+**`Instant` es la mejor opcion para nuestro caso porque:**
+
+1. La Whoop API v2 devuelve timestamps en **ISO-8601 con UTC** (ej: `2024-01-15T08:00:00.000Z`). `Instant.parse()` los lee directamente.
+2. PostgreSQL almacena `TIMESTAMP WITH TIME ZONE` en UTC internamente. `Instant` se mapea a este tipo de forma natural.
+3. Power BI puede convertir UTC a la zona horaria local del dashboard. El dato en BD siempre es "la verdad absoluta".
+4. La Whoop API incluye un campo `timezone_offset` separado (ej: `"-05:00"`), que almacenamos como `String` por si Power BI lo necesita.
+
+---
+
+## 5. Documentacion oficial
+
+- [Jakarta Persistence API (JPA 3.2) Specification](https://jakarta.ee/specifications/persistence/3.2/)
+- [Hibernate ORM 7 User Guide](https://docs.jboss.org/hibernate/orm/7.0/userguide/html_single/Hibernate_User_Guide.html)
+- [Spring Data JPA Reference](https://docs.spring.io/spring-data/jpa/reference/)
+- [Kotlin allOpen plugin](https://kotlinlang.org/docs/all-open-plugin.html)
+- [java.time.Instant JavaDoc](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/time/Instant.html)
+- [AES-GCM (NIST SP 800-38D)](https://csrc.nist.gov/publications/detail/sp/800-38d/final)
+- [JPA AttributeConverter JavaDoc](https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/attributeconverter)
+
+---
+
+> **Siguiente**: [04 - Repositorios](./04-repositorios.md) -- como Spring Data JPA genera queries automaticamente a partir de nombres de metodo.

--- a/docs/04-repositorios.md
+++ b/docs/04-repositorios.md
@@ -1,0 +1,356 @@
+# 04 - Repositorios Spring Data JPA
+
+> Como Spring genera SQL automaticamente a partir de interfaces Kotlin, sin escribir una sola query.
+
+---
+
+## 1. Que es el patron Repository?
+
+El **patron Repository** es una abstraccion que separa la logica de negocio del acceso a datos. En vez de que tu servicio escriba SQL directamente, le pide al repositorio "dame los ciclos entre estas fechas" y el repositorio se encarga del como.
+
+```
+Controller  -->  Service  -->  Repository  -->  Base de datos
+                  (logica)      (abstraccion)    (SQL real)
+```
+
+**Spring Data JPA** lleva este patron al extremo: tu solo defines una **interfaz** con firmas de metodos, y Spring **genera la implementacion completa** en tiempo de ejecucion. No escribes SQL, no escribes clases de implementacion, no escribes nada mas que la interfaz.
+
+```kotlin
+// Tu solo escribes esto:
+interface CycleRepository : JpaRepository<WhoopCycle, Long> {
+    fun findByStartBetween(from: Instant, to: Instant, pageable: Pageable): Page<WhoopCycle>
+}
+
+// Spring genera automaticamente esto (simplificado):
+class CycleRepositoryImpl : CycleRepository {
+    override fun findByStartBetween(from: Instant, to: Instant, pageable: Pageable): Page<WhoopCycle> {
+        val sql = "SELECT * FROM whoop_cycles WHERE start_time BETWEEN ? AND ? ORDER BY ... LIMIT ? OFFSET ?"
+        // ejecutar query, mapear resultados, construir Page...
+    }
+}
+```
+
+---
+
+## 2. Donde se usa en este proyecto?
+
+Los repositorios estan en el paquete `repository`:
+
+| Archivo | Entidad | Tipo de ID |
+|---------|---------|------------|
+| [`src/main/kotlin/.../repository/CycleRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/CycleRepository.kt) | `WhoopCycle` | `Long` |
+| [`src/main/kotlin/.../repository/RecoveryRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/RecoveryRepository.kt) | `WhoopRecovery` | `Long` |
+| [`src/main/kotlin/.../repository/SleepRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/SleepRepository.kt) | `WhoopSleep` | `String` |
+| [`src/main/kotlin/.../repository/WorkoutRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/WorkoutRepository.kt) | `WhoopWorkout` | `String` |
+| [`src/main/kotlin/.../repository/OAuthTokenRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/OAuthTokenRepository.kt) | `OAuthTokenEntity` | `Long` |
+
+Los repositorios se consumen en dos capas:
+
+- **Servicios de lectura** (ej: [`CycleService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/CycleService.kt)): Usan los metodos de filtrado y paginacion para servir datos al API REST.
+- **Servicio de sincronizacion** ([`WhoopSyncService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt)): Usa `findTopByOrderByUpdatedAtDesc()` para sincronizacion incremental y `save()` para persistir datos.
+
+---
+
+## 3. Por que esta decision?
+
+### Por que Spring Data JPA y no escribir queries manuales?
+
+1. **Cero boilerplate**: No necesitas `EntityManager`, `CriteriaBuilder`, ni SQL strings. Defines una interfaz y Spring hace el resto.
+2. **Seguridad de tipos**: Si cambias el nombre de un campo en la entidad (ej: `start` a `startTime`), el metodo `findByStartBetween` ya no compilaria. Spring valida los nombres de metodo contra los campos de la entidad al arrancar la aplicacion.
+3. **Paginacion integrada**: El parametro `Pageable` y el retorno `Page<T>` te dan paginacion completa (total de elementos, total de paginas, tiene siguiente pagina) sin esfuerzo.
+4. **Queries de este proyecto son simples**: Filtros por fecha y paginacion. No hay joins complejos ni subqueries que justifiquen SQL manual.
+
+### Por que `JpaRepository` y no `CrudRepository`?
+
+Spring Data ofrece una jerarquia de interfaces:
+
+```
+Repository                        (vacio, marcador)
+  └── CrudRepository              (save, findById, findAll, delete, count)
+       └── ListCrudRepository     (versiones con List en vez de Iterable)
+            └── JpaRepository     (+ flush, saveAllAndFlush, paginacion con findAll(Pageable))
+```
+
+Usamos `JpaRepository` porque necesitamos **paginacion** (`findAll(Pageable)`) y los metodos batch (`saveAll`), que `CrudRepository` no ofrece directamente.
+
+---
+
+## 4. Codigo explicado
+
+### 4a. `JpaRepository<Entity, IdType>`: que te da gratis
+
+Al extender `JpaRepository<WhoopCycle, Long>`, obtienes **sin escribir nada** estos metodos (entre otros):
+
+| Metodo | SQL generado (simplificado) | Uso en el proyecto |
+|--------|-------|-----|
+| `save(entity)` | `INSERT INTO ... / UPDATE ...` (decide automaticamente) | `WhoopSyncService.syncCycles()` |
+| `saveAll(entities)` | Batch de `INSERT`/`UPDATE` | Tests |
+| `findById(id)` | `SELECT * FROM whoop_cycles WHERE id = ?` | Tests |
+| `findAll()` | `SELECT * FROM whoop_cycles` | - |
+| `findAll(pageable)` | `SELECT * FROM ... ORDER BY ... LIMIT ? OFFSET ?` + `SELECT COUNT(*)...` | `CycleService.getCycles()` |
+| `count()` | `SELECT COUNT(*) FROM whoop_cycles` | - |
+| `deleteById(id)` | `DELETE FROM whoop_cycles WHERE id = ?` | - |
+| `existsById(id)` | `SELECT COUNT(*) > 0 FROM ... WHERE id = ?` | - |
+
+**Nota sobre `save()`**: Este metodo es inteligente. Si la entidad tiene un `@Id` con valor (no null/0), Hibernate verifica si ya existe en la BD:
+- Si **existe**: ejecuta `UPDATE` (merge).
+- Si **no existe**: ejecuta `INSERT` (persist).
+
+Esto es fundamental para la sincronizacion incremental de Whoop: al re-sincronizar datos, los registros existentes se actualizan en vez de duplicarse.
+
+### 4b. `CycleRepository`: anatomia completa de un repositorio
+
+Analicemos [`CycleRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/CycleRepository.kt):
+
+```kotlin
+package com.example.whoopdavidapi.repository
+
+import com.example.whoopdavidapi.model.entity.WhoopCycle
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.Instant
+
+interface CycleRepository : JpaRepository<WhoopCycle, Long> {
+//                                          ^            ^
+//                                     Entidad       Tipo del @Id
+
+    fun findByStartBetween(from: Instant, to: Instant, pageable: Pageable): Page<WhoopCycle>
+    //  |    |     |                                    |                    |
+    //  (a)  (b)   (c)                                  (d)                  (e)
+
+    fun findByStartGreaterThanEqual(from: Instant, pageable: Pageable): Page<WhoopCycle>
+
+    fun findByStartLessThan(to: Instant, pageable: Pageable): Page<WhoopCycle>
+
+    fun findTopByOrderByUpdatedAtDesc(): WhoopCycle?
+    //       |           |          |               |
+    //       (f)         (g)        (h)             (i)
+}
+```
+
+**Desglose del nombre `findByStartBetween`**:
+
+| Parte | Significado |
+|-------|-------------|
+| (a) `find` | Operacion de busqueda (`SELECT`) |
+| (b) `By` | Separador: lo que sigue es el criterio de filtro (`WHERE`) |
+| (c) `StartBetween` | Campo `start` con operador `BETWEEN` |
+| (d) `pageable: Pageable` | Parametro especial: Spring aplica `ORDER BY`, `LIMIT` y `OFFSET` automaticamente |
+| (e) `Page<WhoopCycle>` | Retorno especial: incluye los datos + metadatos de paginacion |
+
+### 4c. Derived Query Methods: como Spring genera SQL a partir de nombres
+
+Spring Data JPA analiza el nombre del metodo y lo "parsea" en una query SQL. Aqui estan las traducciones exactas para nuestro proyecto:
+
+#### `findByStartBetween(from, to, pageable)`
+
+```sql
+SELECT w FROM WhoopCycle w
+WHERE w.start BETWEEN :from AND :to
+ORDER BY ...    -- segun el Pageable
+LIMIT ...       -- segun el Pageable
+OFFSET ...      -- segun el Pageable
+```
+
+En SQL nativo (lo que realmente ejecuta Hibernate contra PostgreSQL):
+
+```sql
+SELECT * FROM whoop_cycles
+WHERE start_time BETWEEN ? AND ?
+ORDER BY start_time DESC
+LIMIT 100 OFFSET 0
+```
+
+#### `findByStartGreaterThanEqual(from, pageable)`
+
+```sql
+SELECT * FROM whoop_cycles
+WHERE start_time >= ?
+ORDER BY start_time DESC
+LIMIT 100 OFFSET 0
+```
+
+#### `findByStartLessThan(to, pageable)`
+
+```sql
+SELECT * FROM whoop_cycles
+WHERE start_time < ?
+ORDER BY start_time DESC
+LIMIT 100 OFFSET 0
+```
+
+#### `findTopByOrderByUpdatedAtDesc()`
+
+```sql
+SELECT * FROM whoop_cycles
+ORDER BY updated_at DESC
+LIMIT 1
+```
+
+**Desglose de cada palabra clave**:
+
+| Palabra clave | SQL equivalente | Ejemplo |
+|---------------|----------------|---------|
+| `findBy` | `SELECT ... WHERE` | `findByStartBetween` |
+| `Between` | `BETWEEN ? AND ?` | `findByStartBetween(from, to)` |
+| `GreaterThanEqual` | `>= ?` | `findByStartGreaterThanEqual(from)` |
+| `LessThan` | `< ?` | `findByStartLessThan(to)` |
+| `Top` (sin numero) | `LIMIT 1` | `findTopByOrderBy...` |
+| `OrderBy` | `ORDER BY` | `findTopByOrderByUpdatedAtDesc` |
+| `Desc` | `DESC` | `OrderByUpdatedAtDesc` |
+
+### 4d. Variaciones entre repositorios: mismo patron, distintos campos
+
+Los cinco repositorios siguen el mismo patron. Las diferencias son:
+
+**[`RecoveryRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/RecoveryRepository.kt)**:
+
+```kotlin
+interface RecoveryRepository : JpaRepository<WhoopRecovery, Long> {
+    fun findByCreatedAtBetween(from: Instant, to: Instant, pageable: Pageable): Page<WhoopRecovery>
+    //         ^^^^^^^^^ filtra por createdAt en vez de start (Recovery no tiene campo start)
+    fun findByCreatedAtGreaterThanEqual(from: Instant, pageable: Pageable): Page<WhoopRecovery>
+    fun findByCreatedAtLessThan(to: Instant, pageable: Pageable): Page<WhoopRecovery>
+    fun findTopByOrderByUpdatedAtDesc(): WhoopRecovery?
+}
+```
+
+Nota: `WhoopRecovery` no tiene campo `start`, asi que los filtros de fecha usan `createdAt`.
+
+**[`SleepRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/SleepRepository.kt)**:
+
+```kotlin
+interface SleepRepository : JpaRepository<WhoopSleep, String> {
+    //                                                ^^^^^^ ID es String (UUID de Whoop)
+    fun findByStartBetween(from: Instant, to: Instant, pageable: Pageable): Page<WhoopSleep>
+    fun findByStartGreaterThanEqual(from: Instant, pageable: Pageable): Page<WhoopSleep>
+    fun findByStartLessThan(to: Instant, pageable: Pageable): Page<WhoopSleep>
+    fun findTopByOrderByUpdatedAtDesc(): WhoopSleep?
+}
+```
+
+**[`WorkoutRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/WorkoutRepository.kt)**:
+
+```kotlin
+interface WorkoutRepository : JpaRepository<WhoopWorkout, String> {
+    //                                                    ^^^^^^ ID es String
+    fun findByStartBetween(from: Instant, to: Instant, pageable: Pageable): Page<WhoopWorkout>
+    fun findByStartGreaterThanEqual(from: Instant, pageable: Pageable): Page<WhoopWorkout>
+    fun findByStartLessThan(to: Instant, pageable: Pageable): Page<WhoopWorkout>
+    fun findTopByOrderByUpdatedAtDesc(): WhoopWorkout?
+}
+```
+
+**[`OAuthTokenRepository.kt`](../src/main/kotlin/com/example/whoopdavidapi/repository/OAuthTokenRepository.kt)** -- el mas simple:
+
+```kotlin
+interface OAuthTokenRepository : JpaRepository<OAuthTokenEntity, Long> {
+    fun findTopByOrderByUpdatedAtDesc(): OAuthTokenEntity?
+}
+```
+
+Solo tiene un metodo custom: obtener el token mas reciente. No necesita filtros por fecha ni paginacion porque solo hay un usuario y pocos tokens historicos.
+
+### 4e. `Page<T>` y `Pageable`: paginacion completa
+
+**`Pageable`** es un objeto que encapsula tres cosas: numero de pagina, tamano de pagina, y ordenamiento.
+
+En [`CycleService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/CycleService.kt) se crea asi:
+
+```kotlin
+val pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "start"))
+//                         ^^^^^^^^^                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//                         page - 1: Spring usa      Ordenar por campo "start"
+//                         paginas base-0, pero      de la entidad, descendente
+//                         nuestra API usa base-1
+```
+
+**`Page<T>`** es el resultado que incluye los datos Y metadatos:
+
+```kotlin
+val result: Page<WhoopCycle> = cycleRepository.findByStartBetween(from, to, pageable)
+
+result.content         // List<WhoopCycle> - los datos de esta pagina
+result.totalElements   // Long - total de registros que coinciden (ej: 150)
+result.totalPages      // Int - total de paginas (ej: 2 si pageSize=100)
+result.hasNext()       // Boolean - hay mas paginas despues de esta?
+result.number          // Int - numero de pagina actual (base-0)
+result.size            // Int - tamano de pagina solicitado
+```
+
+Spring ejecuta **dos queries** automaticamente para construir el `Page`:
+1. `SELECT * FROM whoop_cycles WHERE ... ORDER BY ... LIMIT ? OFFSET ?` (los datos)
+2. `SELECT COUNT(*) FROM whoop_cycles WHERE ...` (el total, para saber cuantas paginas hay)
+
+Estos metadatos se transforman en la respuesta API dentro del servicio:
+
+```kotlin
+// En CycleService.kt
+return PaginatedResponse(
+    data = result.content.map { cycleMapper.toDto(it) },
+    pagination = PaginationInfo(
+        page = page,
+        pageSize = pageSize,
+        totalCount = result.totalElements,  // <-- viene del Page
+        hasMore = result.hasNext()          // <-- viene del Page
+    )
+)
+```
+
+### 4f. `findTopByOrderByUpdatedAtDesc()`: la clave de la sincronizacion incremental
+
+Este metodo aparece en **todos** los repositorios y es fundamental para la estrategia de sincronizacion.
+
+En [`WhoopSyncService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt):
+
+```kotlin
+private fun syncCycles() {
+    // (1) Obtener la fecha del ultimo registro sincronizado
+    val lastUpdated = cycleRepository.findTopByOrderByUpdatedAtDesc()?.updatedAt
+    //                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //                                SELECT * FROM whoop_cycles
+    //                                ORDER BY updated_at DESC
+    //                                LIMIT 1
+    //                                                              ^^^^^^^^^^^
+    //                                                              ?.updatedAt: si no hay
+    //                                                              registros, devuelve null
+
+    // (2) Pedir a Whoop API solo datos posteriores a esa fecha
+    val records = whoopApiClient.getAllCycles(start = lastUpdated)
+    //                                              ^^^^^^^^^^^
+    //                                              Si null: trae todo (primera sincronizacion)
+    //                                              Si tiene valor: trae solo datos nuevos
+
+    // (3) Guardar cada registro (INSERT si nuevo, UPDATE si ya existe)
+    for (record in records) {
+        val cycle = mapToCycle(record)
+        cycleRepository.save(cycle)
+    }
+}
+```
+
+**Por que es importante?**
+
+Sin sincronizacion incremental, cada ejecucion del scheduler descargaria **todos** los datos historicos de Whoop (potencialmente anos de datos). Con `findTopByOrderByUpdatedAtDesc()`:
+
+1. **Primera ejecucion**: No hay datos en BD -> `lastUpdated = null` -> descarga todo el historico.
+2. **Ejecuciones siguientes**: Hay datos -> `lastUpdated = 2024-06-15T10:30:00Z` -> solo descarga datos actualizados despues de esa fecha.
+
+El retorno es `WhoopCycle?` (nullable) para manejar el caso de la primera ejecucion cuando la tabla esta vacia.
+
+---
+
+## 5. Documentacion oficial
+
+- [Spring Data JPA Reference - Query Methods](https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html)
+- [Spring Data JPA - Derived Query Methods (tabla completa de keywords)](https://docs.spring.io/spring-data/jpa/reference/repositories/query-keywords-reference.html)
+- [Spring Data JPA - Paging and Sorting](https://docs.spring.io/spring-data/jpa/reference/repositories/query-methods-details.html#repositories.special-parameters)
+- [JpaRepository JavaDoc](https://docs.spring.io/spring-data/jpa/docs/current/api/org/springframework/data/jpa/repository/JpaRepository.html)
+- [Page Interface JavaDoc](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Page.html)
+
+---
+
+> **Anterior**: [03 - Entidades JPA](./03-entidades-jpa.md)
+>
+> **Siguiente**: [05 - DTOs y MapStruct](./05-dtos-mapstruct.md) -- como separar lo que expones en el API de lo que almacenas en la BD.

--- a/docs/05-dtos-mapstruct.md
+++ b/docs/05-dtos-mapstruct.md
@@ -1,0 +1,472 @@
+# 05 - DTOs y MapStruct
+
+> Como separar lo que expones en el API de lo que almacenas en la BD, y como MapStruct genera el codigo de conversion automaticamente en tiempo de compilacion.
+
+---
+
+## 1. Que son los DTOs?
+
+**DTO (Data Transfer Object)** es un objeto cuyo unico proposito es transportar datos entre capas de la aplicacion. En nuestro caso, los DTOs son lo que el API REST devuelve al cliente (Power BI u otro consumidor).
+
+```
+Base de datos  -->  Entidad JPA  -->  Mapper  -->  DTO  -->  JSON  -->  Cliente
+                    (WhoopCycle)      (toDto)     (CycleDTO)           (Power BI)
+```
+
+**Por que no devolver la entidad directamente?**
+
+1. **Seguridad**: La entidad `OAuthTokenEntity` tiene campos `accessToken` y `refreshToken`. Si la devuelves como JSON, expones tokens OAuth2. Con un DTO, solo expones los campos que decides.
+2. **Desacoplamiento**: Si cambias la estructura de la BD (renombrar columna, anadir campo interno), no rompes el contrato del API. El DTO sigue igual.
+3. **Formato del API vs formato de la BD**: La BD puede tener campos internos (`scoreState = "PENDING_SCORE"`) que quieres representar de forma diferente en el API, o campos que no necesitas exponer.
+4. **Inmutabilidad**: Las entidades JPA usan `var` (mutable, requerido por Hibernate). Los DTOs usan `val` (inmutable), que es mas seguro para transportar datos.
+
+---
+
+## 2. Donde se usa en este proyecto?
+
+### DTOs
+
+| Archivo | Entidad origen | Campos |
+|---------|---------------|--------|
+| [`src/main/kotlin/.../model/dto/CycleDTO.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/CycleDTO.kt) | `WhoopCycle` | 12 campos |
+| [`src/main/kotlin/.../model/dto/RecoveryDTO.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/RecoveryDTO.kt) | `WhoopRecovery` | 12 campos |
+| [`src/main/kotlin/.../model/dto/SleepDTO.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/SleepDTO.kt) | `WhoopSleep` | 26 campos |
+| [`src/main/kotlin/.../model/dto/WorkoutDTO.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/WorkoutDTO.kt) | `WhoopWorkout` | 24 campos |
+| [`src/main/kotlin/.../model/dto/PaginatedResponse.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/PaginatedResponse.kt) | (generico) | Wrapper de paginacion |
+
+### Mappers (MapStruct)
+
+| Archivo | Convierte |
+|---------|-----------|
+| [`src/main/kotlin/.../mapper/CycleMapper.kt`](../src/main/kotlin/com/example/whoopdavidapi/mapper/CycleMapper.kt) | `WhoopCycle` <-> `CycleDTO` |
+| [`src/main/kotlin/.../mapper/RecoveryMapper.kt`](../src/main/kotlin/com/example/whoopdavidapi/mapper/RecoveryMapper.kt) | `WhoopRecovery` <-> `RecoveryDTO` |
+| [`src/main/kotlin/.../mapper/SleepMapper.kt`](../src/main/kotlin/com/example/whoopdavidapi/mapper/SleepMapper.kt) | `WhoopSleep` <-> `SleepDTO` |
+| [`src/main/kotlin/.../mapper/WorkoutMapper.kt`](../src/main/kotlin/com/example/whoopdavidapi/mapper/WorkoutMapper.kt) | `WhoopWorkout` <-> `WorkoutDTO` |
+
+### Donde se consumen
+
+Los mappers se usan en los servicios de lectura. Ejemplo en [`CycleService.kt`](../src/main/kotlin/com/example/whoopdavidapi/service/CycleService.kt):
+
+```kotlin
+@Service
+class CycleService(
+    private val cycleRepository: CycleRepository,
+    private val cycleMapper: CycleMapper             // <-- inyeccion del mapper
+) {
+    fun getCycles(...): PaginatedResponse<CycleDTO> {
+        val result = cycleRepository.findByStartBetween(from, to, pageable)
+        return PaginatedResponse(
+            data = result.content.map { cycleMapper.toDto(it) },  // <-- entidad -> DTO
+            pagination = PaginationInfo(...)
+        )
+    }
+}
+```
+
+---
+
+## 3. Por que esta decision?
+
+### 3a. Por que `data class` para DTOs?
+
+En Kotlin, `data class` es el tipo ideal para DTOs porque el compilador genera automaticamente:
+
+| Metodo generado | Para que sirve |
+|----------------|----------------|
+| `equals()` | Comparar dos DTOs por contenido (no por referencia) |
+| `hashCode()` | Usar DTOs como claves en `HashMap`/`HashSet` |
+| `toString()` | Debug: `CycleDTO(id=12345, userId=67890, strain=15.5, ...)` |
+| `copy()` | Crear una copia modificando solo algunos campos |
+| `componentN()` | Destructuring: `val (id, userId) = cycleDto` |
+
+Ademas, todos los campos son `val` (inmutables), lo que garantiza que un DTO no cambie despues de crearse.
+
+**Recordatorio**: Las entidades JPA usan `class` normal con `var`, no `data class`. Ver [03-entidades-jpa.md](./03-entidades-jpa.md) para la explicacion.
+
+### 3b. Por que MapStruct y no mapeo manual?
+
+**Alternativa 1: Mapeo manual**
+
+```kotlin
+// Tendrias que escribir esto para CADA entidad:
+fun WhoopCycle.toDto() = CycleDTO(
+    id = this.id,
+    userId = this.userId,
+    createdAt = this.createdAt,
+    updatedAt = this.updatedAt,
+    start = this.start,
+    end = this.end,
+    timezoneOffset = this.timezoneOffset,
+    scoreState = this.scoreState,
+    strain = this.strain,
+    kilojoule = this.kilojoule,
+    averageHeartRate = this.averageHeartRate,
+    maxHeartRate = this.maxHeartRate
+)
+// Y tambien la funcion inversa toEntity()...
+// Y repetir para Recovery (12 campos), Sleep (26 campos), Workout (24 campos)...
+```
+
+Problemas del mapeo manual:
+- **Tedioso**: `SleepDTO` tiene 26 campos. Escribir el mapeo a mano son 52+ lineas de codigo repetitivo.
+- **Fragil**: Si anades un campo a la entidad y olvidas anadirlo al mapeo manual, no hay error de compilacion. El campo simplemente se pierde silenciosamente.
+
+**Alternativa 2: MapStruct (lo que usamos)**
+
+```kotlin
+@Mapper(componentModel = "spring")
+interface CycleMapper {
+    fun toDto(entity: WhoopCycle): CycleDTO
+    fun toEntity(dto: CycleDTO): WhoopCycle
+}
+// Fin. MapStruct genera TODO el codigo de mapeo en compilacion.
+```
+
+Ventajas de MapStruct:
+- **Seguridad en compilacion**: Si la entidad tiene un campo `strain` pero el DTO no, MapStruct lanza un **error de compilacion** (no un error en runtime).
+- **Cero reflexion**: El codigo generado es Kotlin/Java puro con getters y setters. No usa reflexion, asi que es tan rapido como el mapeo manual.
+- **Mantenible**: Si anades un campo, MapStruct te avisa si falta el mapeo.
+
+**Alternativa 3: ModelMapper / Dozer (librerias basadas en reflexion)**
+
+Estas librerias mapean por convencion (nombre de campo igual), pero usan reflexion en runtime, son mas lentas, y los errores aparecen en runtime en vez de en compilacion. MapStruct es superior en todos los aspectos.
+
+### 3c. Por que `PaginatedResponse<T>` como wrapper generico?
+
+En vez de devolver `Page<CycleDTO>` directamente de Spring, creamos nuestro propio wrapper:
+
+```kotlin
+data class PaginatedResponse<T>(
+    val data: List<T>,
+    val pagination: PaginationInfo
+)
+```
+
+Razones:
+1. **Control del formato JSON**: `Page<T>` de Spring serializa con muchos campos internos (`pageable`, `sort`, `first`, `last`, `numberOfElements`...). Nuestro wrapper es mas limpio y predecible.
+2. **Consistencia**: Todos los endpoints de la API devuelven el mismo formato, independientemente de la entidad.
+3. **Power BI**: Un formato simple y consistente es mas facil de consumir en Power BI.
+
+---
+
+## 4. Codigo explicado
+
+### 4a. Un DTO completo: `CycleDTO`
+
+[`CycleDTO.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/CycleDTO.kt):
+
+```kotlin
+package com.example.whoopdavidapi.model.dto
+
+import java.time.Instant
+
+data class CycleDTO(               // (1) data class: genera equals, hashCode, toString, copy
+    val id: Long,                   // (2) val: inmutable una vez creado
+    val userId: Long,
+    val createdAt: Instant?,        // (3) Instant?: puede ser null
+    val updatedAt: Instant?,
+    val start: Instant,             // (4) Instant (no nullable): siempre tiene valor
+    val end: Instant?,
+    val timezoneOffset: String?,
+    val scoreState: String,
+    val strain: Float?,             // (5) Campos de score: null si PENDING_SCORE
+    val kilojoule: Float?,
+    val averageHeartRate: Int?,
+    val maxHeartRate: Int?
+)
+```
+
+| # | Concepto | Explicacion |
+|---|---------|-------------|
+| (1) | `data class` | El compilador Kotlin genera `equals()`, `hashCode()`, `toString()`, `copy()` y funciones `componentN()` basados en TODOS los campos del constructor primario. |
+| (2) | `val` | Inmutable. Una vez construido el DTO, ningun campo puede cambiar. Esto es seguro para pasar entre capas. |
+| (3) | `Instant?` | Nullable. `createdAt` puede no existir si el dato aun no fue procesado completamente por Whoop. |
+| (4) | `Instant` (no nullable) | `start` siempre existe. Un ciclo Whoop siempre tiene hora de inicio. |
+| (5) | `Float?` | Los scores son null cuando `scoreState = "PENDING_SCORE"`. En el JSON resultante, estos campos aparecen como `null`. |
+
+**Comparacion entidad vs DTO para Cycle:**
+
+| Campo | Entidad (`class`) | DTO (`data class`) | Diferencia |
+|-------|-------------------|-------------------|------------|
+| `id` | `var id: Long = 0` | `val id: Long` | `var` -> `val`, valor por defecto eliminado |
+| `start` | `var start: Instant = Instant.now()` | `val start: Instant` | Mismo patron |
+| Todos | Mutables (`var`) con defaults | Inmutables (`val`) sin defaults | DTOs son mas estrictos |
+
+### 4b. `PaginatedResponse<T>` y `PaginationInfo`
+
+[`PaginatedResponse.kt`](../src/main/kotlin/com/example/whoopdavidapi/model/dto/PaginatedResponse.kt):
+
+```kotlin
+data class PaginatedResponse<T>(     // (1) Generico: funciona con cualquier DTO
+    val data: List<T>,                // (2) Los datos de esta pagina
+    val pagination: PaginationInfo    // (3) Metadatos de paginacion
+)
+
+data class PaginationInfo(
+    val page: Int,                    // (4) Pagina actual (base-1 para el usuario)
+    val pageSize: Int,                // (5) Tamano de pagina solicitado
+    val totalCount: Long,             // (6) Total de registros que coinciden
+    val hasMore: Boolean              // (7) Hay mas paginas despues?
+)
+```
+
+**`<T>` (generics)**: La `T` permite reutilizar la misma clase para cualquier tipo de DTO:
+
+```kotlin
+PaginatedResponse<CycleDTO>       // Para /api/v1/cycles
+PaginatedResponse<RecoveryDTO>    // Para /api/v1/recoveries
+PaginatedResponse<SleepDTO>       // Para /api/v1/sleeps
+PaginatedResponse<WorkoutDTO>     // Para /api/v1/workouts
+```
+
+**Ejemplo de JSON resultante** cuando un cliente llama a `GET /api/v1/cycles?page=1&pageSize=2`:
+
+```json
+{
+  "data": [
+    {
+      "id": 12345,
+      "userId": 67890,
+      "start": "2024-01-15T08:00:00Z",
+      "end": "2024-01-16T08:00:00Z",
+      "scoreState": "SCORED",
+      "strain": 15.5,
+      "kilojoule": 2500.0,
+      "averageHeartRate": 72,
+      "maxHeartRate": 185
+    },
+    {
+      "id": 12344,
+      "userId": 67890,
+      "start": "2024-01-14T08:00:00Z",
+      "scoreState": "PENDING_SCORE",
+      "strain": null,
+      "kilojoule": null
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "pageSize": 2,
+    "totalCount": 150,
+    "hasMore": true
+  }
+}
+```
+
+### 4c. MapStruct: el mapper como interfaz
+
+[`CycleMapper.kt`](../src/main/kotlin/com/example/whoopdavidapi/mapper/CycleMapper.kt):
+
+```kotlin
+package com.example.whoopdavidapi.mapper
+
+import com.example.whoopdavidapi.model.dto.CycleDTO
+import com.example.whoopdavidapi.model.entity.WhoopCycle
+import org.mapstruct.Mapper
+
+@Mapper(componentModel = "spring")   // (1) Genera un @Component de Spring
+interface CycleMapper {               // (2) Solo una interfaz, sin implementacion
+    fun toDto(entity: WhoopCycle): CycleDTO    // (3) Entidad -> DTO
+    fun toEntity(dto: CycleDTO): WhoopCycle    // (4) DTO -> Entidad
+}
+```
+
+| # | Concepto | Explicacion |
+|---|---------|-------------|
+| (1) | `componentModel = "spring"` | La clase generada por MapStruct tendra `@Component`, lo que permite inyectarla con `@Autowired` o inyeccion por constructor en Spring. |
+| (2) | `interface` | Tu solo declaras QUE quieres mapear. MapStruct genera la implementacion en tiempo de compilacion. |
+| (3) | `toDto` | Convierte una entidad JPA (mutable, con `var`) a un DTO (inmutable, con `val`). Mapea por convencion de nombres: `entity.id` -> `dto.id`, `entity.strain` -> `dto.strain`, etc. |
+| (4) | `toEntity` | Conversion inversa. Se usa cuando necesitas crear una entidad a partir de datos del API (aunque en este proyecto la sincronizacion usa mapeo manual desde JSON). |
+
+**Que genera MapStruct en compilacion?** Algo equivalente a esto (simplificado):
+
+```kotlin
+// Generado automaticamente en build/generated/source/kapt/main/
+@Component
+class CycleMapperImpl : CycleMapper {
+    override fun toDto(entity: WhoopCycle): CycleDTO {
+        return CycleDTO(
+            id = entity.id,
+            userId = entity.userId,
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+            start = entity.start,
+            end = entity.end,
+            timezoneOffset = entity.timezoneOffset,
+            scoreState = entity.scoreState,
+            strain = entity.strain,
+            kilojoule = entity.kilojoule,
+            averageHeartRate = entity.averageHeartRate,
+            maxHeartRate = entity.maxHeartRate
+        )
+    }
+
+    override fun toEntity(dto: CycleDTO): WhoopCycle {
+        return WhoopCycle(
+            id = dto.id,
+            userId = dto.userId,
+            createdAt = dto.createdAt,
+            updatedAt = dto.updatedAt,
+            start = dto.start,
+            end = dto.end,
+            timezoneOffset = dto.timezoneOffset,
+            scoreState = dto.scoreState,
+            strain = dto.strain,
+            kilojoule = dto.kilojoule,
+            averageHeartRate = dto.averageHeartRate,
+            maxHeartRate = dto.maxHeartRate
+        )
+    }
+}
+```
+
+**Mapeo por convencion**: MapStruct mapea campos automaticamente cuando el **nombre y tipo** coinciden. Como `WhoopCycle.id` (Long) y `CycleDTO.id` (Long) tienen el mismo nombre y tipo, no necesitas anotaciones adicionales. Esto funciona para los 12 campos de CycleDTO sin escribir una sola linea de configuracion.
+
+Los otros mappers siguen exactamente el mismo patron:
+
+```kotlin
+// RecoveryMapper.kt
+@Mapper(componentModel = "spring")
+interface RecoveryMapper {
+    fun toDto(entity: WhoopRecovery): RecoveryDTO   // 12 campos mapeados automaticamente
+    fun toEntity(dto: RecoveryDTO): WhoopRecovery
+}
+
+// SleepMapper.kt
+@Mapper(componentModel = "spring")
+interface SleepMapper {
+    fun toDto(entity: WhoopSleep): SleepDTO         // 26 campos mapeados automaticamente
+    fun toEntity(dto: SleepDTO): WhoopSleep
+}
+
+// WorkoutMapper.kt
+@Mapper(componentModel = "spring")
+interface WorkoutMapper {
+    fun toDto(entity: WhoopWorkout): WorkoutDTO     // 24 campos mapeados automaticamente
+    fun toEntity(dto: WorkoutDTO): WhoopWorkout
+}
+```
+
+### 4d. kapt: como MapStruct funciona con Kotlin
+
+**kapt (Kotlin Annotation Processing Tool)** es el puente entre el procesador de anotaciones de Java (que MapStruct usa) y el compilador de Kotlin. Cuando compilas el proyecto:
+
+1. **kapt** analiza tus interfaces Kotlin anotadas con `@Mapper`
+2. Genera stubs Java a partir de ellas (para que el procesador de anotaciones de Java las entienda)
+3. **MapStruct** procesa esos stubs y genera implementaciones Java
+4. El compilador de Kotlin compila todo junto
+
+La configuracion esta en [`build.gradle.kts`](../build.gradle.kts):
+
+```kotlin
+plugins {
+    kotlin("kapt") version "2.2.21"       // (1) Habilita kapt en el proyecto
+}
+
+dependencies {
+    implementation("org.mapstruct:mapstruct:1.6.3")          // (2) API de MapStruct (anotaciones)
+    kapt("org.mapstruct:mapstruct-processor:1.6.3")          // (3) Procesador que genera codigo
+}
+
+kapt {
+    correctErrorTypes = true               // (4) Mejor manejo de errores de tipo
+    includeCompileClasspath = false        // (5) No incluir classpath de compilacion (best practice)
+    arguments {
+        arg("mapstruct.defaultComponentModel", "spring")  // (6) Todas las implementaciones seran @Component
+    }
+}
+```
+
+| # | Concepto | Explicacion |
+|---|---------|-------------|
+| (1) | `kotlin("kapt")` | Plugin de Gradle que habilita el procesamiento de anotaciones para Kotlin. Sin esto, MapStruct no puede generar codigo. |
+| (2) | `implementation("org.mapstruct:mapstruct:1.6.3")` | Las anotaciones que usas en tu codigo (`@Mapper`). Se incluyen en el classpath de compilacion y runtime. |
+| (3) | `kapt("org.mapstruct:mapstruct-processor:1.6.3")` | El procesador que lee las anotaciones y genera las clases de implementacion. Solo se ejecuta en compilacion, no se incluye en el JAR final. |
+| (4) | `correctErrorTypes = true` | Cuando kapt encuentra tipos que no puede resolver completamente, intenta corregirlos en vez de fallar. Util para proyectos mixtos Kotlin/Java. |
+| (5) | `includeCompileClasspath = false` | Optimizacion recomendada: evita que kapt procese anotaciones que no le corresponden. |
+| (6) | `mapstruct.defaultComponentModel = "spring"` | Configuracion global: todas las implementaciones generadas por MapStruct tendran `@Component`, integrando con Spring sin necesidad de especificar `componentModel = "spring"` en cada `@Mapper`. (Lo especificamos en ambos lados por claridad explicita.) |
+
+### 4e. Gotcha de Spring Boot 4: desactivar kapt para test sources
+
+En [`build.gradle.kts`](../build.gradle.kts) hay una configuracion critica:
+
+```kotlin
+// Desactivar kapt para test sources (no hay annotation processors en tests)
+tasks.matching { it.name == "kaptTestKotlin" || it.name == "kaptGenerateStubsTestKotlin" }.configureEach {
+    enabled = false
+}
+```
+
+**Por que es necesario?** En Spring Boot 4, las anotaciones de test (`@WebMvcTest`, `@DataJpaTest`) cambiaron de paquete. Por ejemplo:
+
+```kotlin
+// Spring Boot 3:
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+
+// Spring Boot 4:
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+```
+
+kapt intenta generar stubs para las clases de test, y cuando encuentra estas anotaciones de Spring Boot 4, no puede resolverlas correctamente porque los nuevos paquetes no estan en el classpath de kapt. Esto causa errores de compilacion.
+
+La solucion es simple: como no tenemos procesadores de anotaciones en tests (no hay `@Mapper` ni nada que necesite kapt en `src/test/`), simplemente desactivamos kapt para los sources de test.
+
+### 4f. Flujo completo: del HTTP request al JSON response
+
+Para consolidar todos los conceptos, veamos el flujo completo cuando Power BI llama `GET /api/v1/cycles?from=2024-01-01T00:00:00Z&page=1&pageSize=100`:
+
+```
+1. CycleController.getCycles(from, to, page, pageSize)
+   |
+   v
+2. CycleService.getCycles(from, to, page, pageSize)
+   |
+   |  Crea: PageRequest.of(0, 100, Sort.by(DESC, "start"))
+   |
+   v
+3. CycleRepository.findByStartGreaterThanEqual(from, pageable)
+   |
+   |  Spring genera SQL:
+   |  SELECT * FROM whoop_cycles WHERE start_time >= '2024-01-01T00:00:00Z'
+   |  ORDER BY start_time DESC LIMIT 100 OFFSET 0
+   |
+   |  Hibernate ejecuta SQL contra PostgreSQL
+   |
+   v
+4. Page<WhoopCycle>  (entidades JPA, clases mutables con var)
+   |
+   v
+5. result.content.map { cycleMapper.toDto(it) }
+   |
+   |  MapStruct (CycleMapperImpl) copia campo por campo:
+   |  entity.id -> dto.id
+   |  entity.strain -> dto.strain
+   |  ... (12 campos)
+   |
+   v
+6. List<CycleDTO>  (data classes inmutables con val)
+   |
+   v
+7. PaginatedResponse(data = ..., pagination = PaginationInfo(...))
+   |
+   v
+8. Jackson serializa a JSON
+   |
+   v
+9. HTTP 200 con el JSON de respuesta
+```
+
+---
+
+## 5. Documentacion oficial
+
+- [MapStruct Reference Guide](https://mapstruct.org/documentation/stable/reference/html/)
+- [MapStruct with Kotlin (kapt)](https://mapstruct.org/documentation/installation/#kotlin)
+- [Kotlin data classes](https://kotlinlang.org/docs/data-classes.html)
+- [Kotlin kapt compiler plugin](https://kotlinlang.org/docs/kapt.html)
+- [Spring Data JPA - Projections (DTOs)](https://docs.spring.io/spring-data/jpa/reference/repositories/projections.html)
+- [Jackson Kotlin Module](https://github.com/FasterXML/jackson-module-kotlin)
+
+---
+
+> **Anterior**: [04 - Repositorios](./04-repositorios.md)

--- a/docs/06-servicios.md
+++ b/docs/06-servicios.md
@@ -1,0 +1,443 @@
+# 06 - Capa de Servicios (`@Service`)
+
+## Que es la capa de servicios?
+
+La capa de servicios es la **capa intermedia** entre los controladores REST (que reciben peticiones HTTP) y los repositorios (que acceden a la base de datos). Su responsabilidad es contener la **logica de negocio**: transformar datos, aplicar reglas, coordinar operaciones entre distintos repositorios, etc.
+
+En Spring, se marca una clase como servicio con la anotacion `@Service`. Esto le dice a Spring: "esta clase es un componente que contiene logica de negocio, registrala en el contenedor de inyeccion de dependencias".
+
+```
+Peticion HTTP
+     |
+     v
+Controller  -->  Service  -->  Repository  -->  Base de datos
+     ^              |
+     |              v
+ResponseEntity   MapStruct (Entity -> DTO)
+```
+
+El controlador **no debe** acceder al repositorio directamente. Siempre delega al servicio, que decide como obtener y transformar los datos.
+
+---
+
+## Donde se usa en este proyecto?
+
+Hay **5 servicios** en el proyecto:
+
+| Servicio | Archivo | Responsabilidad |
+|---|---|---|
+| `CycleService` | `src/main/kotlin/com/example/whoopdavidapi/service/CycleService.kt` | Consulta paginada de ciclos fisiologicos |
+| `RecoveryService` | `src/main/kotlin/com/example/whoopdavidapi/service/RecoveryService.kt` | Consulta paginada de recuperaciones |
+| `SleepService` | `src/main/kotlin/com/example/whoopdavidapi/service/SleepService.kt` | Consulta paginada de datos de sueno |
+| `WorkoutService` | `src/main/kotlin/com/example/whoopdavidapi/service/WorkoutService.kt` | Consulta paginada de entrenamientos |
+| `WhoopSyncService` | `src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt` | Orquesta la sincronizacion incremental con la Whoop API |
+
+Los 4 primeros (Cycle, Recovery, Sleep, Workout) siguen un **patron identico**. El quinto (`WhoopSyncService`) tiene una responsabilidad diferente: no sirve datos al usuario, sino que los obtiene de la API externa y los guarda en la base de datos.
+
+---
+
+## Por que una capa de servicios?
+
+1. **Separacion de responsabilidades**: el controlador se limita a validar parametros HTTP y devolver respuestas. El servicio contiene la logica real.
+2. **Reutilizacion**: un mismo servicio puede ser invocado desde un controlador, desde un scheduler, desde un test... sin duplicar codigo.
+3. **Testabilidad**: se puede testear la logica de negocio del servicio en aislamiento, usando mocks para los repositorios, sin necesidad de levantar un servidor HTTP.
+4. **Principio DRY (Don't Repeat Yourself)**: en este proyecto, los 4 servicios de consulta siguen el mismo patron. Si la logica de paginacion cambiara, basta con modificarla en la capa de servicio.
+
+---
+
+## Codigo explicado
+
+### 1. La anotacion `@Service` y component scanning
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/service/CycleService.kt
+
+@Service
+class CycleService(
+    private val cycleRepository: CycleRepository,
+    private val cycleMapper: CycleMapper
+) {
+    // ...
+}
+```
+
+`@Service` es una **especializacion** de `@Component`. Tecnicamente, ambas hacen lo mismo: registrar la clase como un bean en el contenedor de Spring. La diferencia es **semantica**: `@Service` indica que la clase contiene logica de negocio.
+
+Cuando la aplicacion arranca, Spring Boot ejecuta el **component scanning**: escanea todos los paquetes bajo la clase marcada con `@SpringBootApplication` (en este caso, `com.example.whoopdavidapi`) y busca clases anotadas con `@Component`, `@Service`, `@Repository`, `@Controller`, etc. Cada una se registra como un bean singleton que puede ser inyectado en otras clases.
+
+La jerarquia de anotaciones de componentes es:
+
+```
+@Component              <-- Generico (base)
+  |-- @Service          <-- Logica de negocio
+  |-- @Repository        <-- Acceso a datos
+  |-- @Controller        <-- Controladores web
+```
+
+### 2. Inyeccion por constructor (constructor injection en Kotlin)
+
+```kotlin
+@Service
+class CycleService(
+    private val cycleRepository: CycleRepository,
+    private val cycleMapper: CycleMapper
+) {
+```
+
+En Kotlin, el **constructor primario** se declara directamente en la firma de la clase. Spring detecta automaticamente que `CycleService` necesita un `CycleRepository` y un `CycleMapper`, busca beans de esos tipos en su contenedor, y los inyecta al crear la instancia.
+
+**No se necesita `@Autowired`**. Desde Spring 4.3, si una clase tiene un unico constructor, Spring lo usa automaticamente para inyeccion. Como en Kotlin el constructor primario es el unico constructor (a menos que declares constructores secundarios con `constructor`), la inyeccion funciona sin ninguna anotacion adicional.
+
+Las propiedades son `private val` por dos razones:
+- `private`: encapsulacion, ninguna otra clase puede acceder a estas dependencias directamente.
+- `val`: inmutabilidad, una vez asignada la dependencia no puede cambiar.
+
+### 3. Logica de paginacion: `PageRequest.of()`
+
+```kotlin
+fun getCycles(
+    from: Instant?,
+    to: Instant?,
+    page: Int,
+    pageSize: Int
+): PaginatedResponse<CycleDTO> {
+    val pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "start"))
+```
+
+`PageRequest.of()` crea un objeto `Pageable` que Spring Data JPA usa para construir automaticamente las clausulas `LIMIT`, `OFFSET` y `ORDER BY` en la consulta SQL.
+
+La conversion `page - 1` es critica:
+- El **usuario** envia paginas **basadas en 1** (pagina 1, 2, 3...) porque es mas natural para un humano.
+- Spring Data JPA usa paginas **basadas en 0** internamente (pagina 0, 1, 2...).
+- `page - 1` convierte entre ambos sistemas. Si el usuario pide `page=1`, Spring recibe `0` y devuelve los primeros resultados.
+
+`Sort.by(Sort.Direction.DESC, "start")` indica que los resultados se ordenen por el campo `start` de forma descendente (los mas recientes primero). El nombre `"start"` debe coincidir con el nombre del atributo en la entidad JPA (`WhoopCycle.start`), no con el nombre de la columna en la base de datos.
+
+### 4. La expresion `when` para filtrado condicional
+
+```kotlin
+val result = when {
+    from != null && to != null -> cycleRepository.findByStartBetween(from, to, pageable)
+    from != null -> cycleRepository.findByStartGreaterThanEqual(from, pageable)
+    to != null -> cycleRepository.findByStartLessThan(to, pageable)
+    else -> cycleRepository.findAll(pageable)
+}
+```
+
+`when` es la version Kotlin de un `switch` en Java, pero mucho mas potente. Aqui se usa como **expresion** (devuelve un valor que se asigna a `result`), no como sentencia.
+
+Se evaluan las condiciones de arriba a abajo:
+
+| Condicion | Metodo del repositorio | SQL generado (simplificado) |
+|---|---|---|
+| `from` y `to` presentes | `findByStartBetween(from, to, pageable)` | `WHERE start BETWEEN ? AND ?` |
+| Solo `from` presente | `findByStartGreaterThanEqual(from, pageable)` | `WHERE start >= ?` |
+| Solo `to` presente | `findByStartLessThan(to, pageable)` | `WHERE start < ?` |
+| Ninguno presente | `findAll(pageable)` | Sin filtro (todos los registros) |
+
+Los parametros `from` y `to` son `Instant?` (nullable). Esto permite al usuario hacer peticiones como:
+- `/api/v1/cycles` -- sin filtro, devuelve todo paginado.
+- `/api/v1/cycles?from=2024-01-01T00:00:00Z` -- desde esa fecha en adelante.
+- `/api/v1/cycles?from=2024-01-01T00:00:00Z&to=2024-06-01T00:00:00Z` -- rango especifico.
+
+### 5. Mapeo Entity a DTO con MapStruct
+
+```kotlin
+return PaginatedResponse(
+    data = result.content.map { cycleMapper.toDto(it) },
+    pagination = PaginationInfo(
+        page = page,
+        pageSize = pageSize,
+        totalCount = result.totalElements,
+        hasMore = result.hasNext()
+    )
+)
+```
+
+`result` es un `Page<WhoopCycle>` (un objeto de Spring Data que contiene los resultados paginados y metadatos de paginacion).
+
+- `result.content` devuelve la `List<WhoopCycle>` con las entidades de la pagina actual.
+- `.map { cycleMapper.toDto(it) }` transforma cada entidad en su DTO usando MapStruct.
+- `result.totalElements` es el numero **total** de registros en la base de datos que coinciden con el filtro (no solo los de esta pagina).
+- `result.hasNext()` indica si hay mas paginas despues de la actual.
+
+El mapper (`CycleMapper`) es una interfaz generada por MapStruct:
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/mapper/CycleMapper.kt
+
+@Mapper(componentModel = "spring")
+interface CycleMapper {
+    fun toDto(entity: WhoopCycle): CycleDTO
+    fun toEntity(dto: CycleDTO): WhoopCycle
+}
+```
+
+`componentModel = "spring"` hace que MapStruct genere una implementacion anotada con `@Component`, que Spring puede inyectar automaticamente en `CycleService`.
+
+La respuesta paginada se envuelve en un DTO generico:
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/model/dto/PaginatedResponse.kt
+
+data class PaginatedResponse<T>(
+    val data: List<T>,
+    val pagination: PaginationInfo
+)
+
+data class PaginationInfo(
+    val page: Int,
+    val pageSize: Int,
+    val totalCount: Long,
+    val hasMore: Boolean
+)
+```
+
+El JSON que recibe el cliente (Power BI) tiene esta estructura:
+
+```json
+{
+  "data": [ ... ],
+  "pagination": {
+    "page": 1,
+    "pageSize": 100,
+    "totalCount": 542,
+    "hasMore": true
+  }
+}
+```
+
+### 6. Principio DRY: los 4 servicios de consulta son identicos
+
+Los servicios `CycleService`, `RecoveryService`, `SleepService` y `WorkoutService` siguen **exactamente el mismo patron**. La unica diferencia es:
+- El **repositorio** que usan (`CycleRepository`, `RecoveryRepository`, etc.).
+- El **mapper** que usan (`CycleMapper`, `RecoveryMapper`, etc.).
+- El **campo de ordenacion** (`"start"` para Cycle/Sleep/Workout, `"createdAt"` para Recovery).
+
+Por ejemplo, `RecoveryService` difiere solo en que ordena por `"createdAt"` en vez de `"start"`:
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/service/RecoveryService.kt
+
+@Service
+class RecoveryService(
+    private val recoveryRepository: RecoveryRepository,
+    private val recoveryMapper: RecoveryMapper
+) {
+
+    fun getRecoveries(
+        from: Instant?,
+        to: Instant?,
+        page: Int,
+        pageSize: Int
+    ): PaginatedResponse<RecoveryDTO> {
+        val pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))
+
+        val result = when {
+            from != null && to != null -> recoveryRepository.findByCreatedAtBetween(from, to, pageable)
+            from != null -> recoveryRepository.findByCreatedAtGreaterThanEqual(from, pageable)
+            to != null -> recoveryRepository.findByCreatedAtLessThan(to, pageable)
+            else -> recoveryRepository.findAll(pageable)
+        }
+
+        return PaginatedResponse(
+            data = result.content.map { recoveryMapper.toDto(it) },
+            pagination = PaginationInfo(
+                page = page,
+                pageSize = pageSize,
+                totalCount = result.totalElements,
+                hasMore = result.hasNext()
+            )
+        )
+    }
+}
+```
+
+Este patron repetido (4 clases con la misma estructura) es un compromiso consciente: se podria abstraer en una clase generica, pero la simplicidad y legibilidad de tener clases explicitas es preferible cuando hay solo 4 casos.
+
+### 7. WhoopSyncService: la orquestacion de sincronizacion
+
+`WhoopSyncService` tiene una responsabilidad distinta: no sirve datos al usuario, sino que **obtiene datos de la Whoop API y los guarda en la base de datos**.
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt
+
+@Service
+class WhoopSyncService(
+    private val whoopApiClient: WhoopApiClient,
+    private val cycleRepository: CycleRepository,
+    private val recoveryRepository: RecoveryRepository,
+    private val sleepRepository: SleepRepository,
+    private val workoutRepository: WorkoutRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun syncAll() {
+        log.info("Iniciando sincronizacion completa con Whoop API...")
+        val start = System.currentTimeMillis()
+
+        syncCycles()
+        syncRecoveries()
+        syncSleeps()
+        syncWorkouts()
+
+        val elapsed = System.currentTimeMillis() - start
+        log.info("Sincronizacion completa en {} ms", elapsed)
+    }
+```
+
+Puntos clave:
+
+- **5 dependencias inyectadas**: el cliente HTTP (`WhoopApiClient`) y los 4 repositorios. Este servicio orquesta la comunicacion entre la API externa y la base de datos local.
+- **`syncAll()`**: metodo publico que el scheduler (`WhoopDataSyncScheduler`) invoca periodicamente. Sincroniza los 4 tipos de datos en secuencia.
+- **Logging con SLF4J**: `LoggerFactory.getLogger(javaClass)` crea un logger con el nombre de la clase. Los `{}` son placeholders que SLF4J reemplaza solo si el nivel de log esta activo (mas eficiente que concatenar strings).
+- **Medicion de tiempo**: `System.currentTimeMillis()` antes y despues permite registrar cuanto tarda la sincronizacion completa.
+
+### 8. Sincronizacion incremental
+
+```kotlin
+private fun syncCycles() {
+    try {
+        // Sincronizacion incremental: obtener solo datos nuevos
+        val lastUpdated = cycleRepository.findTopByOrderByUpdatedAtDesc()?.updatedAt
+        val records = whoopApiClient.getAllCycles(start = lastUpdated)
+        var saved = 0
+        var skipped = 0
+
+        for (record in records) {
+            try {
+                val cycle = mapToCycle(record)
+                cycleRepository.save(cycle)
+                saved++
+            } catch (ex: IllegalArgumentException) {
+                log.warn("Saltando cycle con datos inválidos: {}", ex.message)
+                skipped++
+            }
+        }
+
+        log.info("Cycles sincronizados: {} nuevos/actualizados, {} saltados", saved, skipped)
+    } catch (ex: Exception) {
+        log.error("Error sincronizando cycles: {}", ex.message, ex)
+    }
+}
+```
+
+La estrategia **incremental** evita re-descargar todo cada vez:
+
+1. `cycleRepository.findTopByOrderByUpdatedAtDesc()` obtiene el registro mas reciente de la BD local (el que tiene `updatedAt` mas alto).
+2. `?.updatedAt` extrae el campo `updatedAt` usando safe call de Kotlin. Si no hay registros, devuelve `null`.
+3. `whoopApiClient.getAllCycles(start = lastUpdated)` pide a la Whoop API solo los registros modificados despues de esa fecha. Si `lastUpdated` es `null` (primera sincronizacion), trae todo.
+4. Cada registro se mapea a entidad y se guarda con `cycleRepository.save()`. Si ya existe (mismo ID), JPA hace un UPDATE en vez de INSERT.
+
+Los metodos `syncRecoveries()`, `syncSleeps()` y `syncWorkouts()` siguen el mismo patron.
+
+### 9. Mapeo de JSON a entidades: safe casts de Kotlin
+
+```kotlin
+private fun mapToCycle(record: Map<String, Any?>): WhoopCycle {
+    val score = record["score"] as? Map<*, *>
+    return WhoopCycle(
+        id = (record["id"] as Number).toLong(),
+        userId = (record["user_id"] as Number).toLong(),
+        createdAt = parseInstant(record["created_at"]),
+        updatedAt = parseInstant(record["updated_at"]),
+        start = requireNotNull(parseInstant(record["start"])) {
+            "Campo 'start' requerido en cycle (id=${record["id"] ?: "desconocido"})"
+        },
+        end = parseInstant(record["end"]),
+        timezoneOffset = record["timezone_offset"] as? String,
+        scoreState = record["score_state"] as? String ?: "PENDING_SCORE",
+        strain = (score?.get("strain") as? Number)?.toFloat(),
+        kilojoule = (score?.get("kilojoule") as? Number)?.toFloat(),
+        averageHeartRate = (score?.get("average_heart_rate") as? Number)?.toInt(),
+        maxHeartRate = (score?.get("max_heart_rate") as? Number)?.toInt()
+    )
+}
+```
+
+Este metodo convierte un `Map<String, Any?>` (respuesta JSON deserializada) a una entidad JPA. Usa varios operadores de Kotlin:
+
+| Operador | Significado | Ejemplo |
+|---|---|---|
+| `as?` | **Safe cast**: intenta castear. Si falla, devuelve `null` en vez de lanzar excepcion. | `record["score"] as? Map<*, *>` |
+| `?.` | **Safe call**: si el objeto es `null`, devuelve `null` sin ejecutar el metodo. | `score?.get("strain")` |
+| `?:` | **Elvis operator**: si la expresion izquierda es `null`, usa el valor de la derecha. | `record["score_state"] as? String ?: "PENDING_SCORE"` |
+| `requireNotNull()` | Lanza `IllegalArgumentException` si el valor es `null`. | `requireNotNull(parseInstant(record["start"])) { "mensaje" }` |
+
+El metodo `parseInstant` convierte strings ISO-8601 a `Instant`:
+
+```kotlin
+private fun parseInstant(value: Any?): Instant? {
+    return when (value) {
+        is String -> try { Instant.parse(value) } catch (_: Exception) { null }
+        else -> null
+    }
+}
+```
+
+Si el valor no es un `String` o no se puede parsear, devuelve `null` en vez de lanzar una excepcion. Esto hace la sincronizacion mas robusta frente a datos inesperados de la API externa.
+
+### 10. El scheduler que invoca al servicio
+
+El `WhoopSyncService` es invocado periodicamente por el scheduler:
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/scheduler/WhoopDataSyncScheduler.kt
+
+@Component
+class WhoopDataSyncScheduler(
+    private val whoopSyncService: WhoopSyncService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "\${app.whoop.sync-cron}")
+    fun scheduledSync() {
+        log.info("Ejecutando sincronizacion programada...")
+        try {
+            whoopSyncService.syncAll()
+        } catch (ex: Exception) {
+            log.error("Error en sincronizacion programada: {}", ex.message, ex)
+        }
+    }
+}
+```
+
+El scheduler es un `@Component`, no un `@Service`, porque su unica responsabilidad es **programar** la ejecucion. La logica de sincronizacion real vive en `WhoopSyncService`. Esta separacion permite que la sincronizacion se pueda disparar de otras formas (un endpoint manual, un test) sin depender del scheduler.
+
+---
+
+## Flujo completo de una peticion
+
+Ejemplo: el usuario (Power BI) pide `GET /api/v1/cycles?from=2024-01-01T00:00:00Z&page=2&pageSize=50`.
+
+```
+1. CycleController recibe la peticion
+   - Valida: page >= 1, pageSize entre 1 y 1000
+   - Delega a cycleService.getCycles(from, null, 2, 50)
+
+2. CycleService.getCycles()
+   - Crea PageRequest.of(1, 50, Sort.by(DESC, "start"))  // page 2 del usuario = page 1 de Spring
+   - Evalua el `when`: from != null, to == null -> findByStartGreaterThanEqual()
+   - El repositorio ejecuta: SELECT * FROM whoop_cycle WHERE start >= ? ORDER BY start DESC LIMIT 50 OFFSET 50
+
+3. CycleService transforma el resultado
+   - Mapea cada WhoopCycle a CycleDTO usando CycleMapper
+   - Envuelve en PaginatedResponse con metadatos de paginacion
+
+4. CycleController devuelve ResponseEntity.ok(resultado)
+   - Spring serializa a JSON y envia con HTTP 200
+```
+
+---
+
+## Documentacion oficial
+
+- **`@Service` y component scanning**: [Spring Framework - Classpath Scanning and Managed Components](https://docs.spring.io/spring-framework/reference/core/beans/classpath-scanning.html)
+- **Inyeccion por constructor**: [Spring Framework - Constructor-based Dependency Injection](https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-collaborators.html#beans-constructor-injection)
+- **`Pageable` y `PageRequest`**: [Spring Data JPA - Paging and Sorting](https://docs.spring.io/spring-data/jpa/reference/repositories/query-methods-details.html#repositories.special-parameters)
+- **`Page<T>` result**: [Spring Data Commons - Page Interface](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Page.html)
+- **MapStruct con Spring**: [MapStruct Reference - Using dependency injection](https://mapstruct.org/documentation/stable/reference/html/#using-dependency-injection)
+- **SLF4J parameterized logging**: [SLF4J FAQ - What is the fastest way of logging?](https://www.slf4j.org/faq.html#logging_performance)
+- **Kotlin safe casts y operadores**: [Kotlin Reference - Type Checks and Casts](https://kotlinlang.org/docs/typecasts.html)

--- a/docs/07-controladores.md
+++ b/docs/07-controladores.md
@@ -1,0 +1,406 @@
+# 07 - Controladores REST (`@RestController`)
+
+## Que es un controlador REST?
+
+Un controlador REST es la **puerta de entrada** a la aplicacion. Recibe peticiones HTTP del cliente (en este caso, Power BI), las valida, delega la logica al servicio correspondiente y devuelve la respuesta en formato JSON.
+
+En Spring, un controlador REST se crea con la anotacion `@RestController`, que es la combinacion de dos anotaciones:
+
+```
+@RestController = @Controller + @ResponseBody
+```
+
+- `@Controller`: registra la clase como un componente web que maneja peticiones HTTP.
+- `@ResponseBody`: indica que el valor devuelto por cada metodo se serializa directamente al cuerpo de la respuesta HTTP (por defecto como JSON), en lugar de buscar una vista/template HTML.
+
+---
+
+## Donde se usa en este proyecto?
+
+| Controlador | Archivo | Endpoint | Patron |
+|---|---|---|---|
+| `CycleController` | `src/main/kotlin/com/example/whoopdavidapi/controller/CycleController.kt` | `GET /api/v1/cycles` | Datos locales (BD) |
+| `RecoveryController` | `src/main/kotlin/com/example/whoopdavidapi/controller/RecoveryController.kt` | `GET /api/v1/recovery` | Datos locales (BD) |
+| `SleepController` | `src/main/kotlin/com/example/whoopdavidapi/controller/SleepController.kt` | `GET /api/v1/sleep` | Datos locales (BD) |
+| `WorkoutController` | `src/main/kotlin/com/example/whoopdavidapi/controller/WorkoutController.kt` | `GET /api/v1/workouts` | Datos locales (BD) |
+| `ProfileController` | `src/main/kotlin/com/example/whoopdavidapi/controller/ProfileController.kt` | `GET /api/v1/profile` | Llamada directa a Whoop API |
+
+Ademas, el proyecto tiene un manejador global de excepciones:
+
+| Clase | Archivo |
+|---|---|
+| `GlobalExceptionHandler` | `src/main/kotlin/com/example/whoopdavidapi/exception/GlobalExceptionHandler.kt` |
+| `WhoopApiException` | `src/main/kotlin/com/example/whoopdavidapi/exception/WhoopApiException.kt` |
+| `ErrorResponse` | `src/main/kotlin/com/example/whoopdavidapi/exception/GlobalExceptionHandler.kt` (declarado en el mismo archivo) |
+
+---
+
+## Por que controladores REST?
+
+1. **Interfaz HTTP estandar**: Power BI consume datos via peticiones GET con parametros de query. Los controladores REST exponen exactamente eso.
+2. **Versionado de API**: el prefijo `/api/v1` permite crear nuevas versiones (`/api/v2`) en el futuro sin romper clientes existentes.
+3. **Separacion de responsabilidades**: el controlador solo se encarga de la capa HTTP (validar parametros, devolver codigos de estado). La logica de negocio vive en los servicios.
+4. **Manejo centralizado de errores**: `@RestControllerAdvice` permite capturar todas las excepciones en un unico lugar, devolviendo respuestas JSON consistentes.
+
+---
+
+## Codigo explicado
+
+### 1. `@RestController` y `@RequestMapping`
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/controller/CycleController.kt
+
+@RestController
+@RequestMapping("/api/v1")
+class CycleController(private val cycleService: CycleService) {
+```
+
+- `@RestController`: marca la clase como controlador REST. Todos los metodos devuelven JSON automaticamente.
+- `@RequestMapping("/api/v1")`: establece el **path base** para todos los endpoints de esta clase. Cada `@GetMapping` dentro de la clase aniade su ruta a este prefijo.
+- Constructor injection: `CycleService` se inyecta automaticamente (igual que en los servicios, no necesita `@Autowired`).
+
+### 2. `@GetMapping` y `@RequestParam`
+
+```kotlin
+@GetMapping("/cycles")
+fun getCycles(
+    @RequestParam(required = false) from: Instant?,
+    @RequestParam(required = false) to: Instant?,
+    @RequestParam(defaultValue = "1") page: Int,
+    @RequestParam(defaultValue = "100") pageSize: Int
+): ResponseEntity<PaginatedResponse<CycleDTO>> {
+```
+
+La ruta final de este endpoint es `/api/v1/cycles` (la suma de `@RequestMapping("/api/v1")` + `@GetMapping("/cycles")`).
+
+`@RequestParam` mapea parametros de la URL (query string) a parametros del metodo:
+
+| Parametro | Configuracion | Ejemplo en URL | Comportamiento |
+|---|---|---|---|
+| `from` | `required = false`, tipo `Instant?` | `?from=2024-01-01T00:00:00Z` | Opcional. Si no se envia, es `null`. |
+| `to` | `required = false`, tipo `Instant?` | `?to=2024-12-31T23:59:59Z` | Opcional. Si no se envia, es `null`. |
+| `page` | `defaultValue = "1"` | `?page=3` | Tiene valor por defecto. Si no se envia, es `1`. |
+| `pageSize` | `defaultValue = "100"` | `?pageSize=50` | Tiene valor por defecto. Si no se envia, es `100`. |
+
+**Conversion automatica de `Instant`**: Spring Boot convierte automaticamente strings ISO-8601 (como `2024-01-01T00:00:00Z`) a objetos `java.time.Instant`. No se necesita ninguna anotacion adicional ni un formatter custom. Spring usa el converter registrado por defecto para tipos `java.time`.
+
+### 3. Validacion con `require()` (precondiciones de Kotlin)
+
+```kotlin
+require(page >= 1) { "page debe ser >= 1" }
+require(pageSize in 1..1000) { "pageSize debe estar entre 1 y 1000" }
+```
+
+`require()` es una funcion de la libreria estandar de Kotlin para validar **precondiciones**. Si la condicion es `false`, lanza una `IllegalArgumentException` con el mensaje proporcionado en el bloque lambda.
+
+| Funcion Kotlin | Lanza | Uso tipico |
+|---|---|---|
+| `require()` | `IllegalArgumentException` | Validar argumentos de entrada |
+| `requireNotNull()` | `IllegalArgumentException` | Validar que un valor no sea null |
+| `check()` | `IllegalStateException` | Validar estado del objeto |
+| `error()` | `IllegalStateException` | Fallar incondicionalmente con mensaje |
+
+En este caso:
+- `page >= 1`: la pagina debe ser al menos 1 (Spring Data usa base 0 internamente, pero el usuario envia base 1).
+- `pageSize in 1..1000`: el tamano de pagina debe estar entre 1 y 1000. Esto previene peticiones que podrian devolver demasiados resultados y sobrecargar el servidor o la base de datos.
+
+La `IllegalArgumentException` lanzada por `require()` es capturada por el `GlobalExceptionHandler` (ver seccion 7) y convertida en una respuesta HTTP 400 con un mensaje descriptivo.
+
+### 4. `ResponseEntity<T>`: control del HTTP response
+
+```kotlin
+return ResponseEntity.ok(cycleService.getCycles(from, to, page, pageSize))
+```
+
+`ResponseEntity<T>` es un wrapper de Spring que permite controlar la respuesta HTTP completa: el **cuerpo** (body), el **codigo de estado** (status code) y los **headers**.
+
+`ResponseEntity.ok(body)` es un atajo para `ResponseEntity.status(200).body(body)`. Metodos estaticos comunes:
+
+| Metodo | Status Code | Uso |
+|---|---|---|
+| `ResponseEntity.ok(body)` | 200 OK | Respuesta exitosa con cuerpo |
+| `ResponseEntity.badRequest().body(body)` | 400 Bad Request | Error de validacion |
+| `ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(body)` | 429 Too Many Requests | Rate limiting |
+| `ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body)` | 500 Internal Server Error | Error inesperado |
+
+**Alternativa sin `ResponseEntity`**: se podria devolver directamente `PaginatedResponse<CycleDTO>` (sin wrappear en `ResponseEntity`). Spring asumira HTTP 200 automaticamente. Pero `ResponseEntity` es preferible porque permite devolver codigos de estado distintos a 200 en otros metodos.
+
+### 5. Serializacion JSON: Spring Boot 4 + Jackson 3
+
+Spring Boot 4 incluye **Jackson 3** como serializador JSON. Una diferencia importante respecto a versiones anteriores:
+
+- **Jackson 3 serializa fechas (`Instant`, `LocalDate`, etc.) como ISO-8601 por defecto**. Ya no es necesario configurar `spring.jackson.serialization.write-dates-as-timestamps=false` como se hacia en Spring Boot 2/3.
+- Los `Instant` se serializan como `"2024-01-15T08:30:00Z"` automaticamente.
+
+Ejemplo de respuesta JSON para `GET /api/v1/cycles?page=1&pageSize=2`:
+
+```json
+{
+  "data": [
+    {
+      "id": 12345,
+      "start": "2024-06-15T04:00:00Z",
+      "end": "2024-06-16T04:00:00Z",
+      "strain": 14.7,
+      "averageHeartRate": 72,
+      "maxHeartRate": 185
+    },
+    {
+      "id": 12344,
+      "start": "2024-06-14T04:00:00Z",
+      "end": "2024-06-15T04:00:00Z",
+      "strain": 8.3,
+      "averageHeartRate": 65,
+      "maxHeartRate": 142
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "pageSize": 2,
+    "totalCount": 542,
+    "hasMore": true
+  }
+}
+```
+
+### 6. ProfileController: un patron diferente
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/controller/ProfileController.kt
+
+@RestController
+@RequestMapping("/api/v1")
+class ProfileController(private val whoopApiClient: WhoopApiClient) {
+
+    @GetMapping("/profile")
+    fun getProfile(): ResponseEntity<Map<String, Any?>> {
+        val profile = whoopApiClient.getUserProfile()
+        return ResponseEntity.ok(profile)
+    }
+}
+```
+
+Este controlador es diferente a los otros 4 porque:
+
+1. **No tiene servicio intermedio**: inyecta directamente `WhoopApiClient` en vez de un servicio.
+2. **No consulta la base de datos**: el perfil del usuario no se almacena localmente, se obtiene en tiempo real de la Whoop API.
+3. **No tiene paginacion ni filtros**: el perfil es un unico objeto, no una coleccion.
+4. **El tipo de retorno es `Map<String, Any?>`**: no hay DTO tipado. La respuesta de la Whoop API se reenvía tal cual.
+
+Este patron es adecuado porque el perfil cambia raramente y es un dato simple que no necesita persistencia local ni transformaciones.
+
+### 7. `@RestControllerAdvice` y manejo global de excepciones
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/exception/GlobalExceptionHandler.kt
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+```
+
+`@RestControllerAdvice` es la combinacion de `@ControllerAdvice` + `@ResponseBody`. Permite definir manejadores de excepciones que aplican a **todos** los controladores de la aplicacion. Sin este mecanismo, cada controlador tendria que manejar sus propias excepciones con bloques try-catch, duplicando codigo.
+
+#### Manejador de WhoopApiException
+
+```kotlin
+@ExceptionHandler(WhoopApiException::class)
+fun handleWhoopApiException(ex: WhoopApiException): ResponseEntity<ErrorResponse> {
+    log.error("Whoop API error: {}", ex.message, ex)
+    val status = when (ex.statusCode) {
+        429 -> HttpStatus.TOO_MANY_REQUESTS
+        401, 403 -> HttpStatus.BAD_GATEWAY
+        else -> HttpStatus.BAD_GATEWAY
+    }
+    return ResponseEntity.status(status).body(
+        ErrorResponse(
+            error = status.reasonPhrase,
+            message = ex.message ?: "Error comunicandose con Whoop API",
+            status = status.value()
+        )
+    )
+}
+```
+
+`@ExceptionHandler(WhoopApiException::class)` indica: "cuando cualquier controlador lance una `WhoopApiException`, ejecuta este metodo".
+
+La logica de mapeo de codigos de estado es:
+- **429 de Whoop** se devuelve como **429 al cliente**: el rate limiting de la API externa se propaga al cliente. Asi Power BI sabe que debe esperar antes de reintentar.
+- **401/403 de Whoop** se devuelve como **502 Bad Gateway**: un error de autenticacion con la API externa es un problema del servidor (este BFF), no del cliente. El 502 indica que el servidor recibio una respuesta invalida de un upstream.
+- **Cualquier otro error** tambien se mapea a **502**: cualquier fallo de comunicacion con la Whoop API se trata como un error del gateway.
+
+#### Manejador de IllegalArgumentException
+
+```kotlin
+@ExceptionHandler(IllegalArgumentException::class)
+fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+    log.warn("Bad request: {}", ex.message)
+    return ResponseEntity.badRequest().body(
+        ErrorResponse(
+            error = "Bad Request",
+            message = ex.message ?: "Parametro invalido",
+            status = 400
+        )
+    )
+}
+```
+
+Este manejador captura las excepciones lanzadas por `require()` en los controladores (por ejemplo, `page < 1` o `pageSize > 1000`). Las devuelve como HTTP 400 Bad Request con un mensaje descriptivo.
+
+Se loguea como `warn` (no `error`) porque un 400 es culpa del cliente, no un fallo del servidor.
+
+#### Manejador generico (catch-all)
+
+```kotlin
+@ExceptionHandler(Exception::class)
+fun handleGenericException(ex: Exception): ResponseEntity<ErrorResponse> {
+    log.error("Unexpected error", ex)
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+        ErrorResponse(
+            error = "Internal Server Error",
+            message = "Error interno del servidor",
+            status = 500
+        )
+    )
+}
+```
+
+Este es el **ultimo recurso**: cualquier excepcion que no sea `WhoopApiException` ni `IllegalArgumentException` se captura aqui. Puntos importantes:
+
+- Se loguea como `error` con la excepcion completa (stacktrace) para debugging.
+- El mensaje al cliente es **generico** (`"Error interno del servidor"`), no expone detalles internos. Esto es una practica de seguridad: nunca revelar stacktraces, nombres de clases o rutas internas al cliente.
+
+### 8. La jerarquia de excepciones
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/exception/WhoopApiException.kt
+
+class WhoopApiException(
+    message: String,
+    val statusCode: Int? = null,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)
+```
+
+`WhoopApiException` extiende `RuntimeException` (excepcion no checked). Es una **excepcion de dominio** que representa cualquier fallo de comunicacion con la Whoop API.
+
+Propiedades:
+- `message`: descripcion del error (heredada de `RuntimeException`).
+- `statusCode`: el codigo HTTP que devolvio la Whoop API (429, 401, 500...). Es nullable porque algunos errores (timeout, fallo de red) no tienen codigo HTTP.
+- `cause`: la excepcion original que causo el error (para encadenar excepciones).
+
+El DTO de respuesta de error:
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/exception/GlobalExceptionHandler.kt
+
+data class ErrorResponse(
+    val error: String,
+    val message: String,
+    val status: Int
+)
+```
+
+Todas las respuestas de error tienen la misma estructura JSON:
+
+```json
+{
+  "error": "Bad Request",
+  "message": "page debe ser >= 1",
+  "status": 400
+}
+```
+
+### 9. Orden de evaluacion de `@ExceptionHandler`
+
+Cuando un controlador lanza una excepcion, Spring busca el manejador mas **especifico** primero:
+
+```
+Excepcion lanzada
+     |
+     v
+Es WhoopApiException? ----Si----> handleWhoopApiException() -> 429/502
+     |
+    No
+     |
+     v
+Es IllegalArgumentException? ----Si----> handleIllegalArgument() -> 400
+     |
+    No
+     |
+     v
+Es Exception? ----Si----> handleGenericException() -> 500
+```
+
+Esto funciona porque `WhoopApiException` y `IllegalArgumentException` son subclases de `Exception`. Spring evalua los handlers de mas especifico a mas generico.
+
+### 10. Los 4 controladores de datos siguen el mismo patron
+
+`CycleController`, `RecoveryController`, `SleepController` y `WorkoutController` son estructuralmente identicos. La unica diferencia es el servicio que invocan y el endpoint que exponen:
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/controller/RecoveryController.kt
+
+@RestController
+@RequestMapping("/api/v1")
+class RecoveryController(private val recoveryService: RecoveryService) {
+
+    @GetMapping("/recovery")
+    fun getRecoveries(
+        @RequestParam(required = false) from: Instant?,
+        @RequestParam(required = false) to: Instant?,
+        @RequestParam(defaultValue = "1") page: Int,
+        @RequestParam(defaultValue = "100") pageSize: Int
+    ): ResponseEntity<PaginatedResponse<RecoveryDTO>> {
+        require(page >= 1) { "page debe ser >= 1" }
+        require(pageSize in 1..1000) { "pageSize debe estar entre 1 y 1000" }
+        return ResponseEntity.ok(recoveryService.getRecoveries(from, to, page, pageSize))
+    }
+}
+```
+
+Resumen de los 5 endpoints de la API:
+
+| Endpoint | Metodo HTTP | Parametros | Autenticacion |
+|---|---|---|---|
+| `/api/v1/cycles` | GET | `from`, `to`, `page`, `pageSize` | Basic Auth |
+| `/api/v1/recovery` | GET | `from`, `to`, `page`, `pageSize` | Basic Auth |
+| `/api/v1/sleep` | GET | `from`, `to`, `page`, `pageSize` | Basic Auth |
+| `/api/v1/workouts` | GET | `from`, `to`, `page`, `pageSize` | Basic Auth |
+| `/api/v1/profile` | GET | ninguno | Basic Auth |
+
+Todos estan bajo `/api/**`, por lo que la cadena de seguridad `@Order(1)` de `SecurityConfig` les aplica Basic Auth (ver `docs/08-seguridad.md`).
+
+---
+
+## Flujo completo de un error
+
+Ejemplo: el cliente envia `GET /api/v1/cycles?page=0`.
+
+```
+1. CycleController.getCycles() recibe page=0
+2. require(page >= 1) falla -> lanza IllegalArgumentException("page debe ser >= 1")
+3. Spring intercepta la excepcion y busca un @ExceptionHandler compatible
+4. GlobalExceptionHandler.handleIllegalArgument() captura la excepcion
+5. Devuelve ResponseEntity con status 400 y cuerpo:
+   {
+     "error": "Bad Request",
+     "message": "page debe ser >= 1",
+     "status": 400
+   }
+```
+
+---
+
+## Documentacion oficial
+
+- **`@RestController`**: [Spring Framework - @RestController](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-restcontroller.html)
+- **`@RequestMapping`**: [Spring Framework - Request Mapping](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-requestmapping.html)
+- **`@RequestParam`**: [Spring Framework - @RequestParam](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-methods/requestparam.html)
+- **`ResponseEntity`**: [Spring Framework - ResponseEntity](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-methods/responseentity.html)
+- **`@RestControllerAdvice`**: [Spring Framework - Controller Advice](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-advice.html)
+- **`@ExceptionHandler`**: [Spring Framework - Exceptions](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-exceptionhandler.html)
+- **Kotlin `require()` y precondiciones**: [Kotlin Standard Library - Preconditions](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/require.html)
+- **Jackson 3 y fechas ISO-8601**: [Spring Boot Reference - JSON](https://docs.spring.io/spring-boot/reference/features/json.html)

--- a/docs/08-seguridad.md
+++ b/docs/08-seguridad.md
@@ -1,0 +1,548 @@
+# 08 - Spring Security (Configuracion Multi-Cadena)
+
+## Que es Spring Security?
+
+Spring Security es el framework de seguridad de Spring. Se encarga de **autenticacion** (verificar quien eres) y **autorizacion** (verificar que puedes hacer). Funciona como una cadena de filtros que se ejecuta **antes** de que la peticion llegue al controlador.
+
+En este proyecto, Spring Security protege la API con tres mecanismos distintos:
+1. **Basic Auth** para los endpoints de datos (`/api/**`): Power BI envia credenciales en cada peticion.
+2. **OAuth2** para el flujo de autorizacion (`/login/**`, `/oauth2/**`): se usa una vez para conectar con la Whoop API.
+3. **Acceso publico** para endpoints de monitorizacion y documentacion (`/actuator/**`, `/swagger-ui/**`, `/mock/**`).
+
+---
+
+## Donde se usa en este proyecto?
+
+| Archivo | Responsabilidad |
+|---|---|
+| `src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt` | 4 cadenas de seguridad + gestion de usuarios |
+| `src/main/kotlin/com/example/whoopdavidapi/util/TokenEncryptor.kt` | Cifrado AES-256-GCM de tokens OAuth2 en la BD |
+| `src/main/kotlin/com/example/whoopdavidapi/util/EncryptedStringConverter.kt` | JPA converter que cifra/descifra automaticamente |
+| `src/main/kotlin/com/example/whoopdavidapi/model/entity/OAuthTokenEntity.kt` | Entidad JPA con tokens cifrados |
+
+---
+
+## Por que esta configuracion?
+
+Este proyecto tiene **tres tipos de consumidores** con necesidades de seguridad distintas:
+
+| Consumidor | Endpoints | Autenticacion | Razon |
+|---|---|---|---|
+| **Power BI** | `/api/**` | Basic Auth (usuario/password) | Power BI soporta Basic Auth nativamente. Es simple y stateless. |
+| **David (una vez)** | `/login/**`, `/oauth2/**` | OAuth2 con Whoop | Para autorizar a esta aplicacion a leer datos de la cuenta Whoop de David. |
+| **Monitorizacion/docs** | `/actuator/**`, `/swagger-ui/**` | Ninguna (publico) | Kubernetes health checks y documentacion interactiva deben ser accesibles sin credenciales. |
+| **Todo lo demas** | Cualquier otra ruta | Denegado | Principio de minimo privilegio: si una ruta no esta explicitamente permitida, se deniega. |
+
+La arquitectura de **multiples cadenas con `@Order`** permite aplicar reglas de seguridad distintas a cada grupo de endpoints, en lugar de una unica configuracion monolitica.
+
+---
+
+## Codigo explicado
+
+### 1. `@Configuration` y `@EnableWebSecurity`
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/config/SecurityConfig.kt
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    @Value("\${app.powerbi.username}") private val powerBiUsername: String,
+    @Value("\${app.powerbi.password}") private val powerBiPassword: String
+) {
+```
+
+- `@Configuration`: marca la clase como fuente de beans de Spring (metodos `@Bean` que Spring gestiona).
+- `@EnableWebSecurity`: activa la configuracion de seguridad web de Spring Security. Sin esta anotacion, Spring Boot aplica una configuracion de seguridad por defecto (que protege todo con un password generado aleatoriamente).
+- `@Value("\${app.powerbi.username}")`: inyecta valores desde `application.yaml`. Las credenciales de Power BI se configuran externamente, no estan hardcodeadas en el codigo.
+
+### 2. `PasswordEncoder` con BCrypt
+
+```kotlin
+@Bean
+fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+```
+
+`BCryptPasswordEncoder` implementa el algoritmo **bcrypt** para hashear passwords. Cuando se guarda un password, bcrypt:
+
+1. Genera un **salt aleatorio** (22 caracteres).
+2. Aplica la funcion de hash con un **cost factor** (por defecto 10, lo que significa 2^10 = 1024 iteraciones).
+3. Produce un hash de ~60 caracteres que incluye el salt, el cost factor y el hash.
+
+Ejemplo de hash bcrypt:
+```
+$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+  |  |  |                                                    |
+  |  |  salt (22 chars)                                      hash
+  |  cost factor (10)
+  version (2a)
+```
+
+Esto es importante porque:
+- El password en texto plano **nunca se almacena**. Solo el hash.
+- Incluso si alguien obtiene el hash, no puede revertirlo a texto plano (bcrypt es una funcion unidireccional).
+- El salt aleatorio evita ataques con rainbow tables.
+- El cost factor hace que el hashing sea intencionalmente lento, dificultando ataques de fuerza bruta.
+
+### 3. `UserDetailsService` con usuario en memoria
+
+```kotlin
+@Bean
+fun userDetailsService(passwordEncoder: PasswordEncoder): UserDetailsService {
+    val user = User.builder()
+        .username(powerBiUsername)
+        .password(passwordEncoder.encode(powerBiPassword))
+        .roles("POWERBI")
+        .build()
+    return InMemoryUserDetailsManager(user)
+}
+```
+
+`UserDetailsService` es la interfaz que Spring Security usa para buscar usuarios. Cuando llega una peticion con Basic Auth, Spring:
+
+1. Extrae el `username` y `password` del header `Authorization`.
+2. Llama a `userDetailsService.loadUserByUsername(username)` para obtener el usuario almacenado.
+3. Compara el password enviado con el hash almacenado usando `passwordEncoder.matches()`.
+4. Si coinciden, la peticion esta autenticada.
+
+`InMemoryUserDetailsManager` es una implementacion que almacena los usuarios **en memoria** (no en base de datos). Es apropiada para este proyecto porque solo hay un unico usuario: el de Power BI. No tiene sentido usar una tabla de usuarios en la base de datos para un solo registro.
+
+- `User.builder()`: API fluida para construir un objeto `UserDetails`.
+- `.username(powerBiUsername)`: el nombre de usuario viene de la configuracion (`application.yaml`).
+- `.password(passwordEncoder.encode(powerBiPassword))`: el password se hashea con bcrypt **antes** de almacenarse.
+- `.roles("POWERBI")`: asigna el rol "POWERBI". Internamente Spring lo convierte a la authority `ROLE_POWERBI`. En este proyecto no se usan roles para control de acceso granular, pero es buena practica asignarlo.
+
+### 4. Arquitectura multi-cadena con `@Order`
+
+Spring Security permite definir **multiples `SecurityFilterChain`**, cada uno con sus propias reglas. Cada cadena tiene un `securityMatcher` que define a que URLs aplica. Las cadenas se evaluan en orden de `@Order` (menor numero = mayor prioridad).
+
+```
+Peticion HTTP entrante
+     |
+     v
+@Order(1): /api/**         -- Coincide? --> Basic Auth, stateless
+     |
+    No
+     |
+     v
+@Order(2): /login/**, /oauth2/**  -- Coincide? --> OAuth2 login
+     |
+    No
+     |
+     v
+@Order(3): /actuator/**, /swagger-ui/**, /mock/**, ...  -- Coincide? --> Permitir todo
+     |
+    No
+     |
+     v
+@Order(4): todo lo demas   -- Catch-all --> DENEGAR
+```
+
+Una peticion solo es procesada por **una cadena**: la primera cuyo `securityMatcher` coincida con la URL.
+
+### 5. Cadena 1 (`@Order(1)`): API endpoints con Basic Auth
+
+```kotlin
+// Cadena para endpoints de la API (Basic Auth, stateless)
+@Bean
+@Order(1)
+fun apiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http
+        .securityMatcher("/api/**")
+        .csrf { it.disable() }
+        .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+        .authorizeHttpRequests { auth ->
+            auth.anyRequest().authenticated()
+        }
+        .httpBasic { }
+    return http.build()
+}
+```
+
+Desglose linea por linea:
+
+**`.securityMatcher("/api/**")`**: esta cadena solo aplica a URLs que empiecen con `/api/`. El `**` es un patron Ant que coincide con cualquier subruta (e.g., `/api/v1/cycles`, `/api/v1/profile`).
+
+**`.csrf { it.disable() }`**: desactiva la proteccion CSRF (Cross-Site Request Forgery). CSRF es relevante para formularios HTML con sesiones basadas en cookies, pero esta API es **stateless** y usa Basic Auth, no cookies. Desactivar CSRF es correcto y necesario para APIs REST.
+
+**`.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }`**: indica que Spring **nunca** creara una sesion HTTP para estos endpoints. Cada peticion debe incluir las credenciales de Basic Auth. Esto es importante porque:
+- Power BI envia credenciales en cada peticion (no mantiene sesion).
+- No se desperdicia memoria del servidor almacenando sesiones.
+- Facilita el escalado horizontal (no hay estado compartido entre replicas).
+
+**`.authorizeHttpRequests { auth -> auth.anyRequest().authenticated() }`**: toda peticion a `/api/**` requiere autenticacion. No hay endpoints publicos dentro de `/api/`.
+
+**`.httpBasic { }`**: activa la autenticacion HTTP Basic. El cliente debe enviar el header:
+```
+Authorization: Basic base64(username:password)
+```
+
+### 6. Cadena 2 (`@Order(2)`): OAuth2 para Whoop
+
+```kotlin
+// Cadena para OAuth2 (flujo de autorizacion con Whoop)
+@Bean
+@Order(2)
+fun oauth2SecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http
+        .securityMatcher("/login/**", "/oauth2/**")
+        .csrf { it.disable() }
+        .oauth2Login { }
+    return http.build()
+}
+```
+
+**`.securityMatcher("/login/**", "/oauth2/**")`**: aplica a las rutas del flujo OAuth2. `/login/oauth2/code/whoop` es donde la Whoop API redirige despues de que David autorice la aplicacion. `/oauth2/**` son las rutas internas de Spring para manejar el handshake.
+
+**`.oauth2Login { }`**: activa el flujo OAuth2 Authorization Code. Spring Security se encarga de:
+1. Redirigir al usuario a la pagina de autorizacion de Whoop.
+2. Recibir el callback con el codigo de autorizacion.
+3. Intercambiar el codigo por tokens de acceso y refresco.
+4. Almacenar los tokens (en este proyecto, en la base de datos via `OAuthTokenEntity`).
+
+Este flujo se ejecuta una sola vez: David visita `/login` en un navegador, autoriza la aplicacion, y los tokens se guardan. A partir de ese momento, la sincronizacion automatica usa los tokens almacenados (y los renueva automaticamente cuando expiran).
+
+### 7. Cadena 3 (`@Order(3)`): Endpoints publicos
+
+```kotlin
+// Cadena para endpoints publicos (actuator, H2 console)
+@Bean
+@Order(3)
+fun publicSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http
+        .securityMatcher(
+            "/actuator/**", "/h2-console/**", "/mock/**",
+            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
+        )
+        .csrf { it.disable() }
+        .headers { headers -> headers.frameOptions { it.sameOrigin() } }
+        .authorizeHttpRequests { auth ->
+            auth.anyRequest().permitAll()
+        }
+    return http.build()
+}
+```
+
+**Endpoints publicos y su proposito**:
+
+| Ruta | Proposito |
+|---|---|
+| `/actuator/**` | Health checks de Kubernetes (`/actuator/health`). Deben ser accesibles sin auth para que K8s detecte si el pod esta vivo. |
+| `/h2-console/**` | Consola web de H2 para desarrollo. Solo disponible en perfil `dev`. |
+| `/mock/**` | Endpoints mock para testing sin API keys reales (perfil `demo`). |
+| `/v3/api-docs/**` | Definicion OpenAPI en JSON (usado por Swagger UI). |
+| `/swagger-ui/**`, `/swagger-ui.html` | Interfaz web interactiva para probar la API. |
+
+**`.headers { headers -> headers.frameOptions { it.sameOrigin() } }`**: permite que la consola H2 se cargue dentro de un `<iframe>`. Por defecto, Spring Security bloquea iframes como proteccion contra clickjacking. `sameOrigin()` permite iframes solo si provienen del mismo dominio.
+
+**`.authorizeHttpRequests { auth -> auth.anyRequest().permitAll() }`**: todas las peticiones a estos endpoints se permiten sin autenticacion.
+
+### 8. Cadena 4 (`@Order(4)`): Deny-all (catch-all)
+
+```kotlin
+// Cadena catch-all para el resto de requests (denegar por defecto)
+@Bean
+@Order(4)
+fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    http
+        .csrf { it.disable() }
+        .authorizeHttpRequests { auth ->
+            auth.anyRequest().denyAll()
+        }
+    return http.build()
+}
+```
+
+Esta cadena **no tiene `securityMatcher`**, por lo que coincide con cualquier URL que no haya sido capturada por las cadenas anteriores. `denyAll()` devuelve HTTP 403 Forbidden para cualquier peticion.
+
+Esto implementa el **principio de minimo privilegio** (principle of least privilege): todo esta prohibido por defecto. Solo los endpoints explicitamente configurados en las cadenas 1, 2 y 3 son accesibles.
+
+Sin esta cadena, Spring Boot aplicaria su configuracion de seguridad por defecto, que podria permitir accesos no deseados.
+
+### 9. Cifrado de tokens OAuth2: `TokenEncryptor`
+
+Los tokens OAuth2 (access token y refresh token) se almacenan en la base de datos. Son datos **extremadamente sensibles**: quien tenga un access token puede acceder a los datos de salud de David en la Whoop API. Por eso se cifran en reposo con AES-256-GCM.
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/util/TokenEncryptor.kt
+
+@Component
+class TokenEncryptor(
+    @Value("\${app.security.encryption-key:#{null}}") private val encryptionKey: String?
+) {
+    private val algorithm = "AES/GCM/NoPadding"
+    private val keySpec: SecretKeySpec
+    private val secureRandom = SecureRandom()
+
+    companion object {
+        private const val GCM_IV_LENGTH = 12 // 96 bits recommended for GCM
+        private const val GCM_TAG_LENGTH = 128 // 128 bits authentication tag
+    }
+```
+
+**AES-256-GCM** (Advanced Encryption Standard con Galois/Counter Mode):
+- **AES-256**: cifrado simetrico con clave de 256 bits. Es el estandar de la industria, aprobado por el NIST y usado por gobiernos y entidades financieras.
+- **GCM** (Galois/Counter Mode): modo de operacion que proporciona **confidencialidad** (los datos son ilegibles sin la clave) y **autenticidad** (se detecta si los datos cifrados han sido modificados). GCM es un modo **AEAD** (Authenticated Encryption with Associated Data).
+- **NoPadding**: GCM no necesita padding porque opera como un stream cipher.
+
+**Parametros del cifrado**:
+- **IV (Initialization Vector)**: 12 bytes (96 bits) aleatorios, generados con `SecureRandom`. Un IV distinto para cada operacion de cifrado garantiza que el mismo texto plano produce ciphertexts diferentes cada vez. Esto es critico: reutilizar un IV con la misma clave rompe completamente la seguridad de GCM.
+- **Tag de autenticacion**: 128 bits. Es un "checksum criptografico" que detecta si el ciphertext ha sido modificado (tamper detection).
+- **Clave**: 32 bytes (256 bits) codificados en Base64. Se configura en `application.yaml` y se puede generar con `openssl rand -base64 32`.
+
+#### Validacion de la clave en el bloque `init`
+
+```kotlin
+init {
+    // Fallar si no hay clave configurada
+    require(!encryptionKey.isNullOrBlank()) {
+        "app.security.encryption-key debe estar configurada. No se permite clave por defecto."
+    }
+
+    // Interpretar la clave como Base64 y decodificarla
+    val keyBytes = try {
+        Base64.getDecoder().decode(encryptionKey)
+    } catch (ex: IllegalArgumentException) {
+        throw IllegalArgumentException(
+            "app.security.encryption-key debe ser una cadena Base64 válida que represente exactamente 32 bytes. " +
+            "Ejemplo para generar: openssl rand -base64 32",
+            ex
+        )
+    }
+
+    // Validar que la clave decodificada tenga exactamente 32 bytes (256 bits)
+    require(keyBytes.size == 32) {
+        "app.security.encryption-key debe representar exactamente 32 bytes (256 bits) tras decodificar Base64. " +
+        "Actual: ${keyBytes.size} bytes. Genera una clave segura con: openssl rand -base64 32"
+    }
+
+    // Usar directamente los 32 bytes decodificados como clave AES-256
+    keySpec = SecretKeySpec(keyBytes, "AES")
+}
+```
+
+El bloque `init` de Kotlin se ejecuta cuando se crea la instancia del bean. Aqui se valida la clave de cifrado de forma estricta:
+
+1. **No puede estar vacia**: no se permite una clave por defecto (`#{null}` en el `@Value` significa que si la propiedad no existe, sera `null`). Si la clave no esta configurada, la aplicacion **no arranca**. Esto es intencional: es preferible fallar al inicio que ejecutar sin cifrado.
+2. **Debe ser Base64 valido**: se decodifica para obtener los bytes reales.
+3. **Debe tener exactamente 32 bytes**: AES-256 requiere una clave de exactamente 256 bits (32 bytes). Si la clave tiene otro tamano, la aplicacion falla con un mensaje que explica como generar una clave correcta.
+
+#### Proceso de cifrado
+
+```kotlin
+fun encrypt(plainText: String?): String? {
+    // Solo retornar null si el valor es null (no si es blank)
+    if (plainText == null) return null
+
+    return try {
+        val cipher = Cipher.getInstance(algorithm)
+
+        // Generar IV aleatorio de 12 bytes (96 bits) para GCM
+        val iv = ByteArray(GCM_IV_LENGTH)
+        secureRandom.nextBytes(iv)
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec)
+        val encryptedBytes = cipher.doFinal(plainText.toByteArray(Charsets.UTF_8))
+
+        // Combinar IV + ciphertext (que incluye el tag de autenticación) y codificar en Base64
+        val combined = iv + encryptedBytes
+        Base64.getEncoder().encodeToString(combined)
+    } catch (ex: Exception) {
+        throw IllegalStateException("Error procesando credenciales")
+    }
+}
+```
+
+Flujo de cifrado:
+
+```
+Texto plano ("eyJhbGci...")
+     |
+     v
+UTF-8 bytes
+     |
+     v
+AES-256-GCM encrypt (con IV aleatorio de 12 bytes)
+     |
+     v
+IV (12 bytes) + ciphertext + tag (16 bytes)
+     |
+     v
+Base64 encode
+     |
+     v
+String almacenado en BD ("SGVsbG8gV29ybGQ...")
+```
+
+El IV se prepone al ciphertext porque es necesario para descifrar. No es secreto (puede estar en texto plano), pero debe ser unico para cada operacion de cifrado.
+
+El mensaje de error generico (`"Error procesando credenciales"`) es intencional: no se revelan detalles criptograficos al exterior.
+
+#### Proceso de descifrado
+
+```kotlin
+fun decrypt(encryptedText: String?): String? {
+    if (encryptedText == null) return null
+
+    return try {
+        val cipher = Cipher.getInstance(algorithm)
+
+        // Decodificar Base64 y separar IV + ciphertext
+        val combined = Base64.getDecoder().decode(encryptedText)
+
+        // Validar que existan al menos 12 bytes de IV y > 0 bytes de ciphertext
+        if (combined.size <= GCM_IV_LENGTH) {
+            throw IllegalStateException("Datos cifrados inválidos")
+        }
+
+        val iv = combined.take(GCM_IV_LENGTH).toByteArray()
+        val ciphertext = combined.drop(GCM_IV_LENGTH).toByteArray()
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmSpec)
+        val decryptedBytes = cipher.doFinal(ciphertext)
+        String(decryptedBytes, Charsets.UTF_8)
+    } catch (ex: Exception) {
+        throw IllegalStateException("Error procesando credenciales")
+    }
+}
+```
+
+Flujo de descifrado (inverso al cifrado):
+
+```
+String de BD ("SGVsbG8gV29ybGQ...")
+     |
+     v
+Base64 decode
+     |
+     v
+Separar: IV (primeros 12 bytes) | ciphertext + tag (el resto)
+     |
+     v
+AES-256-GCM decrypt (verifica tag de autenticacion)
+     |
+     v
+UTF-8 string -> Texto plano ("eyJhbGci...")
+```
+
+La validacion `combined.size <= GCM_IV_LENGTH` previene un caso borde: si los datos cifrados estan corruptos o truncados, se detecta antes de intentar descifrar.
+
+Si el tag de autenticacion no coincide (porque los datos fueron modificados), `cipher.doFinal()` lanza una `AEADBadTagException`. Esto se captura en el bloque catch y se convierte en un error generico.
+
+### 10. `EncryptedStringConverter`: cifrado automatico con JPA
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/util/EncryptedStringConverter.kt
+
+@Converter
+@Component
+class EncryptedStringConverter(
+    private val encryptor: TokenEncryptor
+) : AttributeConverter<String?, String?> {
+
+    override fun convertToDatabaseColumn(attribute: String?): String? {
+        return encryptor.encrypt(attribute)
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): String? {
+        return encryptor.decrypt(dbData)
+    }
+}
+```
+
+`AttributeConverter<String?, String?>` es una interfaz de JPA que permite transformar automaticamente un atributo de entidad antes de guardarlo y despues de leerlo de la base de datos:
+
+- `convertToDatabaseColumn`: se llama cuando JPA va a hacer INSERT o UPDATE. Cifra el token antes de guardarlo.
+- `convertToEntityAttribute`: se llama cuando JPA lee de la BD. Descifra el token para que la aplicacion trabaje con texto plano.
+
+El converter se aplica en la entidad con la anotacion `@Convert`:
+
+```kotlin
+// src/main/kotlin/com/example/whoopdavidapi/model/entity/OAuthTokenEntity.kt
+
+@Entity
+@Table(name = "oauth_tokens")
+class OAuthTokenEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "access_token", length = 4096)
+    @Convert(converter = EncryptedStringConverter::class)
+    var accessToken: String? = null,
+
+    @Column(name = "refresh_token", length = 4096)
+    @Convert(converter = EncryptedStringConverter::class)
+    var refreshToken: String? = null,
+
+    // ... otros campos
+)
+```
+
+La columna tiene `length = 4096` porque el cifrado agrega overhead:
+- IV: 12 bytes
+- Token original: hasta ~2KB
+- Tag de autenticacion GCM: 16 bytes
+- Base64 encoding: +33% de overhead
+- Total: el texto cifrado es significativamente mas largo que el original
+
+Esto significa que el codigo de la aplicacion trabaja con tokens en texto plano (para enviarlos a la Whoop API), pero en la base de datos estan siempre cifrados. El cifrado/descifrado es **transparente**: ni los servicios ni los repositorios necesitan saber que los tokens estan cifrados.
+
+---
+
+## Flujo completo de autenticacion
+
+### Peticion Basic Auth (Power BI pide datos)
+
+```
+1. Power BI envia: GET /api/v1/cycles
+   Header: Authorization: Basic cG93ZXJiaTpzZWNyZXQ=    (base64 de "powerbi:secret")
+
+2. Spring Security evalua las cadenas:
+   - @Order(1): securityMatcher("/api/**") -> COINCIDE
+
+3. Cadena API procesa:
+   - CSRF: desactivado (ok para API stateless)
+   - Session: STATELESS (no crear sesion)
+   - httpBasic: decodifica Base64 -> username="powerbi", password="secret"
+
+4. Spring llama a userDetailsService.loadUserByUsername("powerbi")
+   - Encuentra el usuario en InMemoryUserDetailsManager
+   - Compara bcrypt hash del password almacenado con "secret"
+   - Coincide -> autenticado
+
+5. authorizeHttpRequests: anyRequest().authenticated() -> OK
+6. La peticion llega a CycleController.getCycles()
+```
+
+### Peticion denegada (ruta no configurada)
+
+```
+1. Alguien envia: GET /admin/dashboard
+
+2. Spring Security evalua las cadenas:
+   - @Order(1): /api/** -> no coincide
+   - @Order(2): /login/**, /oauth2/** -> no coincide
+   - @Order(3): /actuator/**, /h2-console/**, /mock/**, /swagger-ui/** -> no coincide
+   - @Order(4): catch-all sin securityMatcher -> COINCIDE
+
+3. Cadena default: denyAll() -> HTTP 403 Forbidden
+```
+
+---
+
+## Documentacion oficial
+
+- **Spring Security Architecture**: [Spring Security Reference - Architecture](https://docs.spring.io/spring-security/reference/servlet/architecture.html)
+- **Multiple SecurityFilterChain**: [Spring Security Reference - Multiple HttpSecurity](https://docs.spring.io/spring-security/reference/servlet/configuration/java.html#_multiple_httpsecurity)
+- **`@Order`**: [Spring Framework - @Order](https://docs.spring.io/spring-framework/reference/core/beans/classpath-scanning.html#beans-scanning-autodetection)
+- **HTTP Basic Authentication**: [Spring Security Reference - HTTP Basic](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/basic.html)
+- **OAuth2 Login**: [Spring Security Reference - OAuth2 Login](https://docs.spring.io/spring-security/reference/servlet/oauth2/login/core.html)
+- **`SessionCreationPolicy`**: [Spring Security Reference - Session Management](https://docs.spring.io/spring-security/reference/servlet/authentication/session-management.html)
+- **CSRF Protection**: [Spring Security Reference - CSRF](https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html)
+- **`BCryptPasswordEncoder`**: [Spring Security Reference - Password Encoding](https://docs.spring.io/spring-security/reference/features/authentication/password-storage.html#authentication-password-storage-bcrypt)
+- **`InMemoryUserDetailsManager`**: [Spring Security Reference - In-Memory Authentication](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/in-memory.html)
+- **AES-GCM (NIST SP 800-38D)**: [NIST - Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode](https://csrc.nist.gov/publications/detail/sp/800-38d/final)
+- **JPA `AttributeConverter`**: [Jakarta Persistence Specification - AttributeConverter](https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#a12796)

--- a/docs/09-cliente-http.md
+++ b/docs/09-cliente-http.md
@@ -1,0 +1,601 @@
+# 09 - Cliente HTTP y Resilience4j
+
+## Tabla de contenidos
+
+- [RestClient: el cliente HTTP moderno de Spring](#restclient-el-cliente-http-moderno-de-spring)
+  - [Que es?](#que-es)
+  - [Donde se configura?](#donde-se-configura)
+  - [API fluida: como se hacen las peticiones](#api-fluida-como-se-hacen-las-peticiones)
+  - [URI builder con query parameters](#uri-builder-con-query-parameters)
+  - [Timeouts con SimpleClientHttpRequestFactory](#timeouts-con-simpleclienthttprequestfactory)
+- [WhoopApiClient: consumo de la API paginada](#whoopapiclient-consumo-de-la-api-paginada)
+  - [Que problema resuelve?](#que-problema-resuelve)
+  - [WhoopPageResponse: la estructura de pagina](#whooppageresponse-la-estructura-de-pagina)
+  - [getAllRecords(): el metodo generico de paginacion](#getallrecords-el-metodo-generico-de-paginacion)
+  - [Inyeccion del Bearer token](#inyeccion-del-bearer-token)
+- [TokenManager: patron Strategy](#tokenmanager-patron-strategy)
+  - [La interfaz](#la-interfaz)
+  - [WhoopTokenManager: gestion real de tokens OAuth2](#whooptokenmanager-gestion-real-de-tokens-oauth2)
+  - [DemoWhoopTokenManager: token estatico para demos](#demowhooptokenmanager-token-estatico-para-demos)
+  - [Como Spring elige cual inyectar](#como-spring-elige-cual-inyectar)
+- [Resilience4j: resiliencia ante fallos externos](#resilience4j-resiliencia-ante-fallos-externos)
+  - [Que es Resilience4j?](#que-es-resilience4j)
+  - [CircuitBreaker](#circuitbreaker)
+  - [Retry](#retry)
+  - [RateLimiter](#ratelimiter)
+  - [Metodos fallback](#metodos-fallback)
+  - [Por que se necesita AOP](#por-que-se-necesita-aop)
+- [Documentacion oficial](#documentacion-oficial)
+
+---
+
+## RestClient: el cliente HTTP moderno de Spring
+
+### Que es?
+
+`RestClient` es el cliente HTTP **sincrono** introducido en **Spring Framework 6.1** (y por tanto disponible desde Spring Boot 3.2 en adelante). Es el reemplazo moderno de `RestTemplate`.
+
+Diferencias clave con `RestTemplate`:
+
+| Aspecto | `RestTemplate` (legacy) | `RestClient` (moderno) |
+|---|---|---|
+| **Estilo** | Metodos con muchos parametros | API fluida (builder + method chaining) |
+| **URI** | Strings con placeholders | Lambda con `UriBuilder` tipado |
+| **Mantenimiento** | En modo mantenimiento | Desarrollo activo |
+| **Lectura** | Dificil de leer con muchos params | Legible y expresivo |
+
+**Importante**: `RestClient` es sincrono (bloqueante). Para un cliente reactivo no-bloqueante existe `WebClient`, pero en este proyecto usamos WebMVC (bloqueante), asi que `RestClient` es la eleccion correcta.
+
+### Donde se configura?
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/config/WhoopClientConfig.kt`
+
+```kotlin
+@Configuration
+class WhoopClientConfig(
+    @Value("\${app.whoop.base-url}") private val baseUrl: String,
+    @Value("\${app.whoop.connect-timeout:10}") private val connectTimeoutSeconds: Long,
+    @Value("\${app.whoop.read-timeout:30}") private val readTimeoutSeconds: Long
+) {
+
+    @Bean
+    fun whoopRestClient(): RestClient {
+        // Configurar timeouts para evitar bloqueos indefinidos
+        val requestFactory = SimpleClientHttpRequestFactory().apply {
+            setConnectTimeout(java.time.Duration.ofSeconds(connectTimeoutSeconds))
+            setReadTimeout(java.time.Duration.ofSeconds(readTimeoutSeconds))
+        }
+
+        return RestClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeader("Content-Type", "application/json")
+            .requestFactory(requestFactory)
+            .build()
+    }
+}
+```
+
+Desglose paso a paso:
+
+1. **`@Configuration`**: Marca la clase como fuente de beans de Spring. Spring la procesa al arrancar y registra los beans que definen sus metodos `@Bean`.
+
+2. **`@Value("\${app.whoop.base-url}")`**: Inyecta el valor de la propiedad `app.whoop.base-url` desde `application.yaml`. El valor por defecto es `https://api.prod.whoop.com` (definido en el YAML base), pero el perfil `demo` lo sobreescribe a `http://localhost:8080/mock`.
+
+3. **`@Value("\${app.whoop.connect-timeout:10}")`**: El `:10` despues de los dos puntos es un **valor por defecto**. Si la propiedad no existe en ningun YAML, usa `10` (segundos). La propiedad si esta definida en `application.yaml` con valor `10`, pero el default asegura que la aplicacion no falle si se elimina accidentalmente.
+
+4. **`RestClient.builder()`**: Patron Builder. Se configura paso a paso y al final `.build()` crea la instancia inmutable.
+
+5. **`.baseUrl(baseUrl)`**: Todas las llamadas que haga este `RestClient` partiran de esta URL base. Si despues se hace `.uri("/developer/v1/cycle")`, la URL completa sera `https://api.prod.whoop.com/developer/v1/cycle`.
+
+6. **`.defaultHeader("Content-Type", "application/json")`**: Cabecera que se incluira en **todas** las peticiones de este cliente. Asi no hay que repetirla en cada llamada.
+
+7. **`.requestFactory(requestFactory)`**: Conecta la fabrica de conexiones HTTP con los timeouts configurados (explicados mas abajo).
+
+### API fluida: como se hacen las peticiones
+
+Una vez creado el `RestClient`, las peticiones se construyen con method chaining:
+
+```kotlin
+val response = whoopRestClient.get()           // (1) Metodo HTTP
+    .uri("/developer/v1/cycle")                 // (2) Path (se suma a baseUrl)
+    .header("Authorization", "Bearer $token")   // (3) Cabecera por peticion
+    .retrieve()                                 // (4) Ejecutar la peticion
+    .body(WhoopPageResponse::class.java)        // (5) Deserializar el JSON a este tipo
+```
+
+| Paso | Metodo | Que hace |
+|---|---|---|
+| 1 | `.get()` | Indica que es una peticion HTTP GET. Tambien existen `.post()`, `.put()`, `.delete()`, `.patch()` |
+| 2 | `.uri(...)` | Especifica el path. Se concatena con `baseUrl` del builder |
+| 3 | `.header(...)` | Anade una cabecera a esta peticion concreta (no a todas) |
+| 4 | `.retrieve()` | Ejecuta la peticion HTTP y obtiene la respuesta. Si el servidor devuelve un error (4xx, 5xx), lanza una excepcion |
+| 5 | `.body(...)` | Deserializa el cuerpo de la respuesta JSON al tipo indicado. Jackson (el serializador JSON de Spring) se encarga automaticamente |
+
+### URI builder con query parameters
+
+Cuando la URL necesita parametros de consulta opcionales (como `?limit=25&start=2024-01-01`), se usa una **lambda con `UriBuilder`**:
+
+```kotlin
+.uri { uriBuilder ->
+    uriBuilder.path(path)
+        .queryParam("limit", 25)
+    start?.let { uriBuilder.queryParam("start", it.toString()) }
+    end?.let { uriBuilder.queryParam("end", it.toString()) }
+    nextToken?.let { uriBuilder.queryParam("nextToken", it) }
+    uriBuilder.build()
+}
+```
+
+Por que una lambda y no un String?
+
+- **Parametros opcionales**: Con `?.let { ... }` solo se anade el parametro si no es `null`. Con un String habria que construir la query manualmente concatenando.
+- **Codificacion automatica**: `UriBuilder` codifica automaticamente caracteres especiales (como `+` en timestamps). Asi se evitan bugs sutiles de encoding.
+- **Type-safe**: No hay riesgo de errores por concatenacion de strings.
+
+Ejemplo de URL resultante:
+```
+https://api.prod.whoop.com/developer/v1/cycle?limit=25&start=2024-12-01T00:00:00Z&nextToken=abc123
+```
+
+### Timeouts con SimpleClientHttpRequestFactory
+
+```kotlin
+val requestFactory = SimpleClientHttpRequestFactory().apply {
+    setConnectTimeout(java.time.Duration.ofSeconds(connectTimeoutSeconds))
+    setReadTimeout(java.time.Duration.ofSeconds(readTimeoutSeconds))
+}
+```
+
+Dos timeouts diferentes:
+
+| Timeout | Valor por defecto | Que protege |
+|---|---|---|
+| **Connect timeout** | 10 segundos | Tiempo maximo para **establecer** la conexion TCP con el servidor. Si Whoop esta caido, no esperamos eternamente |
+| **Read timeout** | 30 segundos | Tiempo maximo para **recibir** la respuesta una vez conectados. Si Whoop esta lento, cortamos despues de 30s |
+
+Sin timeouts, una peticion HTTP a un servidor que no responde bloquearia el hilo **indefinidamente**. Esto es critico porque:
+
+1. Spring WebMVC usa un pool de hilos limitado (normalmente 200 hilos por defecto en Tomcat).
+2. Si todas las peticiones se quedan esperando, el pool se agota y la aplicacion deja de responder.
+3. El `@Scheduled` de sincronizacion tambien se bloquearia, impidiendo futuras sincronizaciones.
+
+Los valores se configuran en `application.yaml`:
+```yaml
+app:
+  whoop:
+    connect-timeout: 10  # Tiempo max para establecer conexion
+    read-timeout: 30     # Tiempo max para leer respuesta
+```
+
+---
+
+## WhoopApiClient: consumo de la API paginada
+
+### Que problema resuelve?
+
+La Whoop API devuelve datos **paginados**: cada peticion devuelve maximo 25 registros y un `next_token` para pedir la pagina siguiente. `WhoopApiClient` encapsula esta logica de paginacion para que el resto de la aplicacion simplemente llame `getAllCycles()` y reciba **todos** los registros.
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/client/WhoopApiClient.kt`
+
+### WhoopPageResponse: la estructura de pagina
+
+```kotlin
+data class WhoopPageResponse(
+    val records: List<Map<String, Any?>> = emptyList(),
+    val next_token: String? = null
+)
+```
+
+Esta `data class` interna modela la estructura JSON que devuelve la Whoop API:
+
+```json
+{
+  "records": [ { "id": 1000, "strain": 14.5, ... }, ... ],
+  "next_token": "abc123"
+}
+```
+
+- **`records`**: Lista de registros de la pagina actual. Se usa `Map<String, Any?>` en vez de un DTO tipado porque la estructura varia entre endpoints (cycles, recovery, sleep, workout). El mapeo a entidades se hace despues en `WhoopSyncService`.
+- **`next_token`**: Si es `null`, no hay mas paginas. Si tiene valor, hay que hacer otra peticion incluyendo este token.
+
+### getAllRecords(): el metodo generico de paginacion
+
+```kotlin
+private fun getAllRecords(path: String, start: Instant?, end: Instant?): List<Map<String, Any?>> {
+    val allRecords = mutableListOf<Map<String, Any?>>()
+    var nextToken: String? = null
+
+    do {
+        val token = tokenManager.getValidAccessToken()
+        val response = whoopRestClient.get()
+            .uri { uriBuilder ->
+                uriBuilder.path(path)
+                    .queryParam("limit", 25)
+                start?.let { uriBuilder.queryParam("start", it.toString()) }
+                end?.let { uriBuilder.queryParam("end", it.toString()) }
+                nextToken?.let { uriBuilder.queryParam("nextToken", it) }
+                uriBuilder.build()
+            }
+            .header("Authorization", "Bearer $token")
+            .retrieve()
+            .body(WhoopPageResponse::class.java)
+            ?: throw WhoopApiException("Respuesta vacía de Whoop API al obtener registros de '$path' (nextToken=$nextToken)")
+
+        allRecords.addAll(response.records)
+        nextToken = response.next_token
+        log.debug("Obtenidos {} registros de {}, nextToken={}", response.records.size, path, nextToken)
+    } while (nextToken != null)
+
+    log.info("Total {} registros obtenidos de {}", allRecords.size, path)
+    return allRecords
+}
+```
+
+Flujo paso a paso:
+
+1. **`val allRecords = mutableListOf<>()`**: Lista acumuladora donde se van agregando los registros de cada pagina.
+2. **`var nextToken: String? = null`**: En la primera iteracion no hay token de paginacion.
+3. **`do { ... } while (nextToken != null)`**: Bucle que sigue pidiendo paginas mientras exista `next_token`.
+4. **`tokenManager.getValidAccessToken()`**: Se pide un token valido **en cada iteracion**. Esto es importante porque si hay muchas paginas, el token podria expirar durante la paginacion. El `TokenManager` se encarga de refrescarlo si esta proximo a expirar.
+5. **`.queryParam("limit", 25)`**: Pide el maximo de registros por pagina (25 es el limite de Whoop API).
+6. **`allRecords.addAll(response.records)`**: Acumula los registros de esta pagina.
+7. **`nextToken = response.next_token`**: Actualiza el token de paginacion. Si es `null`, el bucle termina.
+
+Los metodos publicos son wrappers que llaman a `getAllRecords` con el path correcto:
+
+```kotlin
+@CircuitBreaker(name = "whoopApi", fallbackMethod = "fallbackGetAllRecords")
+@Retry(name = "whoopApi")
+@RateLimiter(name = "whoopApi")
+fun getAllCycles(start: Instant? = null, end: Instant? = null): List<Map<String, Any?>> {
+    return getAllRecords("/developer/v1/cycle", start, end)
+}
+
+// ... getAllRecoveries -> "/developer/v1/recovery"
+// ... getAllSleeps -> "/developer/v1/activity/sleep"
+// ... getAllWorkouts -> "/developer/v1/activity/workout"
+```
+
+Cada metodo publico tiene las mismas tres anotaciones de Resilience4j. Las anotaciones deben estar en el metodo **publico** porque Resilience4j usa proxies AOP que solo interceptan llamadas externas (mas sobre esto en la seccion de AOP).
+
+### Inyeccion del Bearer token
+
+```kotlin
+.header("Authorization", "Bearer $token")
+```
+
+El patron de autenticacion con la Whoop API es **OAuth2 Bearer Token**: cada peticion incluye la cabecera `Authorization` con el prefijo `Bearer` seguido del access token. El token se obtiene de `TokenManager`, que es una interfaz (no una clase concreta). Esto es el **patron Strategy**.
+
+---
+
+## TokenManager: patron Strategy
+
+### La interfaz
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/client/TokenManager.kt`
+
+```kotlin
+interface TokenManager {
+    fun getValidAccessToken(): String
+}
+```
+
+Una interfaz con un unico metodo. Define **que** se necesita (un access token valido) sin especificar **como** se obtiene. Esto permite tener multiples implementaciones y que Spring inyecte la correcta segun el perfil activo.
+
+### WhoopTokenManager: gestion real de tokens OAuth2
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/client/WhoopTokenManager.kt`
+
+```kotlin
+@Component
+@org.springframework.context.annotation.Profile("!demo")
+class WhoopTokenManager(
+    private val tokenRepository: OAuthTokenRepository,
+    @Value("\${spring.security.oauth2.client.registration.whoop.client-id}") private val clientId: String,
+    @Value("\${spring.security.oauth2.client.registration.whoop.client-secret}") private val clientSecret: String,
+    @Value("\${spring.security.oauth2.client.provider.whoop.token-uri}") private val tokenUri: String
+) : TokenManager {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val refreshClient = RestClient.builder().build()
+
+    override fun getValidAccessToken(): String {
+        val token = tokenRepository.findTopByOrderByUpdatedAtDesc()
+            ?: throw WhoopApiException("No hay token OAuth2 guardado. Realiza el flujo de autorizacion primero.")
+
+        // Si el token expira en menos de 5 minutos, refrescarlo
+        if (token.expiresAt.isBefore(Instant.now().plusSeconds(300))) {
+            log.info("Access token expira pronto, refrescando...")
+            return refreshToken(token)
+        }
+
+        return token.accessToken
+            ?: throw WhoopApiException("Token OAuth2 guardado pero access_token es null. Realiza el flujo de autorizacion de nuevo.")
+    }
+```
+
+Puntos importantes:
+
+1. **`@Profile("!demo")`**: El `!` es una negacion. Esta clase esta activa en **todos** los perfiles **excepto** `demo`. Cuando se ejecuta con `--spring.profiles.active=dev` o `prod`, Spring crea este bean. Cuando se ejecuta con `demo`, no lo crea.
+
+2. **`tokenRepository.findTopByOrderByUpdatedAtDesc()`**: Busca en la tabla `oauth_tokens` el token mas reciente (ordenado por `updated_at` descendente). Es un **derived query** de Spring Data JPA.
+
+3. **Logica de refresco (5 minutos)**: `token.expiresAt.isBefore(Instant.now().plusSeconds(300))` verifica si el token expira dentro de los proximos 300 segundos (5 minutos). Si es asi, lo refresca proactivamente. Esto previene que expire justo en medio de una sincronizacion paginada.
+
+4. **Metodo `refreshToken()`**: Hace una peticion POST al endpoint de tokens de Whoop con `grant_type=refresh_token`:
+
+```kotlin
+private fun refreshToken(token: OAuthTokenEntity): String {
+    val refreshToken = token.refreshToken
+        ?: throw WhoopApiException("No hay refresh token disponible. Realiza el flujo de autorizacion de nuevo.")
+
+    val formData = LinkedMultiValueMap<String, String>()
+    formData.add("grant_type", "refresh_token")
+    formData.add("refresh_token", refreshToken)
+    formData.add("client_id", clientId)
+    formData.add("client_secret", clientSecret)
+
+    val response = refreshClient.post()
+        .uri(tokenUri)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .body(formData)
+        .retrieve()
+        .body(Map::class.java)
+        ?: throw WhoopApiException("Respuesta vacia al refrescar token")
+
+    val newAccessToken = response["access_token"] as? String
+        ?: throw WhoopApiException("No se recibio access_token al refrescar")
+    val newRefreshToken = response["refresh_token"] as? String
+    val expiresIn = (response["expires_in"] as? Number)?.toLong() ?: 3600L
+    val scope = response["scope"] as? String
+
+    saveToken(newAccessToken, newRefreshToken, expiresIn, scope)
+    log.info("Token refrescado exitosamente")
+    return newAccessToken
+}
+```
+
+- **`LinkedMultiValueMap`**: Es la estructura que Spring usa para codificar datos `application/x-www-form-urlencoded` (el formato que OAuth2 espera para refresh de tokens). Es como un `Map<String, List<String>>`.
+- **`refreshClient`**: Se crea un `RestClient` separado (sin `baseUrl`) porque el endpoint de tokens de Whoop (`https://api.prod.whoop.com/oauth/oauth2/token`) ya se configura como URI completa via `@Value`.
+- **`saveToken(...)`**: Guarda el nuevo access token y refresh token en base de datos para la proxima vez.
+
+### DemoWhoopTokenManager: token estatico para demos
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/mock/DemoWhoopTokenManager.kt`
+
+```kotlin
+@Component
+@Profile("demo")
+@Primary
+class DemoWhoopTokenManager : TokenManager {
+
+    override fun getValidAccessToken(): String = "demo-access-token"
+}
+```
+
+Solo 4 lineas de logica. Siempre devuelve el string `"demo-access-token"`. No hace ninguna llamada HTTP ni consulta base de datos.
+
+### Como Spring elige cual inyectar
+
+Cuando `WhoopApiClient` pide un `TokenManager`:
+
+```kotlin
+class WhoopApiClient(
+    private val whoopRestClient: RestClient,
+    private val tokenManager: TokenManager  // <-- cual implementacion?
+)
+```
+
+Spring decide asi:
+
+| Perfil activo | Beans disponibles | Bean inyectado |
+|---|---|---|
+| `dev` o `prod` | Solo `WhoopTokenManager` (porque `@Profile("!demo")`) | `WhoopTokenManager` |
+| `demo` | `WhoopTokenManager` NO se crea. `DemoWhoopTokenManager` SI se crea | `DemoWhoopTokenManager` |
+| `dev,demo` | Ambos existen (dev activa `!demo` = false? No: `!demo` se evalua y demo esta activo, asi que `WhoopTokenManager` NO se crea). Solo `DemoWhoopTokenManager` | `DemoWhoopTokenManager` |
+
+La anotacion **`@Primary`** en `DemoWhoopTokenManager` es una precaucion adicional: si por alguna razon ambos beans existieran a la vez, Spring usaria el marcado como `@Primary`. Es un patron defensivo habitual.
+
+---
+
+## Resilience4j: resiliencia ante fallos externos
+
+### Que es Resilience4j?
+
+Resilience4j es una libreria de resiliencia para Java/Kotlin que implementa patrones para manejar **fallos de servicios externos**. Cuando tu aplicacion depende de una API externa (como Whoop), esa API puede:
+
+- Caerse temporalmente
+- Responder muy lento
+- Tener limites de peticiones (rate limits)
+
+Sin Resilience4j, un fallo en Whoop se propagaria directamente a tu aplicacion (excepciones, timeouts, bloqueos). Resilience4j anade capas de proteccion.
+
+En este proyecto, las tres anotaciones se aplican a cada metodo publico de `WhoopApiClient`:
+
+```kotlin
+@CircuitBreaker(name = "whoopApi", fallbackMethod = "fallbackGetAllRecords")
+@Retry(name = "whoopApi")
+@RateLimiter(name = "whoopApi")
+fun getAllCycles(start: Instant? = null, end: Instant? = null): List<Map<String, Any?>> {
+```
+
+### CircuitBreaker
+
+El patron **Circuit Breaker** (interruptor de circuito) funciona como un interruptor electrico: si detecta demasiados fallos, "abre" el circuito y deja de hacer peticiones durante un tiempo.
+
+**Tres estados:**
+
+```
+                 fallo > umbral
+    ┌──────────┐ ─────────────> ┌──────────┐
+    │  CLOSED  │                │   OPEN   │
+    │ (normal) │ <───────────── │ (parado) │
+    └──────────┘   tras espera  └──────────┘
+         ^                           │
+         │    prueba peticiones       │
+         │       ┌───────────┐       │
+         └────── │ HALF_OPEN │ <─────┘
+          exito  │ (probando)│  wait-duration
+                 └───────────┘
+```
+
+| Estado | Comportamiento |
+|---|---|
+| **CLOSED** (cerrado) | Estado normal. Todas las peticiones pasan. Se monitorizan los fallos |
+| **OPEN** (abierto) | Las peticiones **no se ejecutan**. Se devuelve el fallback inmediatamente. Protege tanto a tu app como al servidor caido |
+| **HALF_OPEN** (semi-abierto) | Se permiten unas pocas peticiones de prueba para ver si el servicio se recupero. Si tienen exito, vuelve a CLOSED. Si fallan, vuelve a OPEN |
+
+**Configuracion en `application.yaml`:**
+
+```yaml
+resilience4j:
+  circuitbreaker:
+    instances:
+      whoopApi:
+        register-health-indicator: true
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+```
+
+| Propiedad | Valor | Significado |
+|---|---|---|
+| `register-health-indicator` | `true` | Registra el estado del circuit breaker en el endpoint `/actuator/health` |
+| `sliding-window-size` | `10` | Se analizan las **ultimas 10** llamadas para calcular la tasa de fallo |
+| `minimum-number-of-calls` | `5` | No se abre el circuito hasta que se hayan hecho al menos 5 llamadas (evita abrir con poca evidencia) |
+| `failure-rate-threshold` | `50` | Si el 50% o mas de las ultimas 10 llamadas fallan, se abre el circuito |
+| `wait-duration-in-open-state` | `30s` | Tras abrir, espera 30 segundos antes de probar de nuevo (HALF_OPEN) |
+| `permitted-number-of-calls-in-half-open-state` | `3` | En estado HALF_OPEN, permite 3 peticiones de prueba |
+
+**Ejemplo practico**: Si de las ultimas 10 llamadas a Whoop, 5 devuelven error 500, el circuit breaker se abre. Durante 30 segundos, todas las llamadas devuelven el fallback sin intentar contactar a Whoop. Despues de 30s, permite 3 peticiones de prueba. Si esas 3 funcionan, vuelve a CLOSED.
+
+### Retry
+
+El patron **Retry** reintenta peticiones que fallan. Es util para errores **transitorios** (un timeout puntual, un error 503 temporal).
+
+```yaml
+resilience4j:
+  retry:
+    instances:
+      whoopApi:
+        max-attempts: 3
+        wait-duration: 2s
+        enable-exponential-backoff: true
+        exponential-backoff-multiplier: 2
+```
+
+| Propiedad | Valor | Significado |
+|---|---|---|
+| `max-attempts` | `3` | Intenta la peticion hasta 3 veces (1 original + 2 reintentos) |
+| `wait-duration` | `2s` | Espera base entre reintentos |
+| `enable-exponential-backoff` | `true` | Cada reintento espera mas que el anterior |
+| `exponential-backoff-multiplier` | `2` | Factor de multiplicacion exponencial |
+
+Con exponential backoff, las esperas son:
+- 1er intento: falla -> espera **2s**
+- 2do intento: falla -> espera **4s** (2s x 2)
+- 3er intento: falla -> se propaga la excepcion al circuit breaker
+
+**Por que exponential backoff?** Si el servidor esta sobrecargado, reintentar inmediatamente solo empeora la situacion. Esperando cada vez mas, se le da tiempo al servidor para recuperarse.
+
+### RateLimiter
+
+El **Rate Limiter** limita cuantas peticiones se pueden hacer en un periodo de tiempo. Protege contra exceder los limites de la API externa.
+
+```yaml
+resilience4j:
+  ratelimiter:
+    instances:
+      whoopApi:
+        limit-for-period: 90
+        limit-refresh-period: 60s
+        timeout-duration: 10s
+```
+
+| Propiedad | Valor | Significado |
+|---|---|---|
+| `limit-for-period` | `90` | Maximo 90 peticiones por periodo |
+| `limit-refresh-period` | `60s` | El periodo se reinicia cada 60 segundos |
+| `timeout-duration` | `10s` | Si se excede el limite, espera hasta 10s a que se libere un permiso. Si no se libera, lanza excepcion |
+
+Esto significa: maximo **90 peticiones por minuto** a la Whoop API. Si la sincronizacion intenta hacer la peticion numero 91 dentro del mismo minuto, se bloquea hasta 10 segundos esperando que se reinicie el periodo. Si no lo consigue, falla.
+
+### Metodos fallback
+
+Cuando el circuit breaker esta abierto (o se agotan los reintentos), se ejecuta el **metodo fallback** en vez de lanzar una excepcion:
+
+```kotlin
+@CircuitBreaker(name = "whoopApi", fallbackMethod = "fallbackGetAllRecords")
+fun getAllCycles(start: Instant? = null, end: Instant? = null): List<Map<String, Any?>> {
+    return getAllRecords("/developer/v1/cycle", start, end)
+}
+
+@Suppress("UNUSED_PARAMETER")
+private fun fallbackGetAllRecords(start: Instant?, end: Instant?, ex: Throwable): List<Map<String, Any?>> {
+    log.warn("Circuit breaker abierto para Whoop API: {}", ex.message)
+    return emptyList()
+}
+```
+
+Reglas de los metodos fallback:
+
+1. **Mismos parametros** que el metodo original, **mas** un parametro `Throwable` al final (la excepcion que causo el fallo).
+2. **Mismo tipo de retorno** que el metodo original (`List<Map<String, Any?>>`).
+3. El nombre del fallback se especifica en la anotacion: `fallbackMethod = "fallbackGetAllRecords"`.
+
+En este proyecto, los fallbacks devuelven listas vacias. El resultado es que si Whoop esta caido, la sincronizacion simplemente no importa datos nuevos (no falla con excepcion). Cuando Whoop vuelva, la siguiente sincronizacion funcionara normalmente.
+
+Hay tambien un fallback especifico para el metodo `getUserProfile()`:
+
+```kotlin
+@Suppress("UNUSED_PARAMETER")
+private fun fallbackGetProfile(ex: Throwable): Map<String, Any?> {
+    log.warn("Circuit breaker abierto para perfil Whoop: {}", ex.message)
+    return mapOf("error" to "Whoop API no disponible temporalmente")
+}
+```
+
+### Por que se necesita AOP
+
+Las anotaciones `@CircuitBreaker`, `@Retry` y `@RateLimiter` funcionan mediante **AOP (Aspect-Oriented Programming)**. Esto requiere la dependencia:
+
+**En `build.gradle.kts`:**
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-aspectj")
+```
+
+**Nota importante (Spring Boot 4)**: En Spring Boot 3.x era `spring-boot-starter-aop`. En **Spring Boot 4** se renombro a `spring-boot-starter-aspectj`.
+
+Como funciona AOP con estas anotaciones:
+
+1. Spring crea un **proxy** alrededor de `WhoopApiClient`.
+2. Cuando algo llama a `getAllCycles()`, no llama al metodo directamente. Llama al proxy.
+3. El proxy ejecuta la logica de Resilience4j **antes** y **despues** del metodo real:
+   - **RateLimiter**: Verifica si hay permisos disponibles. Si no, espera o falla.
+   - **Retry**: Ejecuta el metodo. Si falla, espera y reintenta.
+   - **CircuitBreaker**: Verifica el estado del circuito. Si esta abierto, ejecuta el fallback sin llamar al metodo real.
+
+```
+Llamada a getAllCycles()
+  └─> Proxy AOP
+       └─> RateLimiter (controla velocidad)
+            └─> Retry (reintenta si falla)
+                 └─> CircuitBreaker (corta si muchos fallos)
+                      └─> getAllRecords() (metodo real)
+```
+
+**Importante**: Por esta razon, las anotaciones solo funcionan en metodos **publicos** llamados desde **fuera** de la clase. Si un metodo privado llama a otro metodo de la misma clase, el proxy no intercepta la llamada. Es por eso que `getAllRecords()` es privado y las anotaciones estan en los metodos publicos `getAllCycles()`, `getAllRecoveries()`, etc.
+
+---
+
+## Documentacion oficial
+
+- [Spring RestClient](https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-restclient) - Documentacion oficial de RestClient
+- [Resilience4j Documentation](https://resilience4j.readme.io/docs) - Documentacion oficial de Resilience4j
+- [Resilience4j CircuitBreaker](https://resilience4j.readme.io/docs/circuitbreaker) - Circuit breaker en detalle
+- [Resilience4j Retry](https://resilience4j.readme.io/docs/retry) - Retry en detalle
+- [Resilience4j RateLimiter](https://resilience4j.readme.io/docs/ratelimiter) - Rate limiter en detalle
+- [Spring AOP](https://docs.spring.io/spring-framework/reference/core/aop.html) - Programacion orientada a aspectos en Spring
+- [OAuth 2.0 Token Refresh (RFC 6749)](https://datatracker.ietf.org/doc/html/rfc6749#section-6) - Especificacion del flujo de refresh token

--- a/docs/10-sincronizacion.md
+++ b/docs/10-sincronizacion.md
@@ -1,0 +1,388 @@
+# 10 - Sincronizacion programada
+
+## Tabla de contenidos
+
+- [Que es @Scheduled?](#que-es-scheduled)
+- [Habilitacion con @EnableScheduling](#habilitacion-con-enablescheduling)
+- [WhoopDataSyncScheduler: el disparador](#whoopdatasyncscheduler-el-disparador)
+  - [Cron expression externalizada](#cron-expression-externalizada)
+  - [Formato de cron en Spring (6 campos)](#formato-de-cron-en-spring-6-campos)
+  - [Manejo de errores en el scheduler](#manejo-de-errores-en-el-scheduler)
+- [WhoopSyncService: la logica de sincronizacion](#whoopsyncservice-la-logica-de-sincronizacion)
+  - [Sincronizacion incremental](#sincronizacion-incremental)
+  - [Independencia entre sincronizaciones](#independencia-entre-sincronizaciones)
+  - [Mapeo JSON a entidades](#mapeo-json-a-entidades)
+  - [parseInstant(): conversion segura de String a Instant](#parseinstant-conversion-segura-de-string-a-instant)
+  - [requireNotNull(): validacion de campos obligatorios](#requirenotnull-validacion-de-campos-obligatorios)
+- [Flujo completo de una sincronizacion](#flujo-completo-de-una-sincronizacion)
+- [Documentacion oficial](#documentacion-oficial)
+
+---
+
+## Que es @Scheduled?
+
+`@Scheduled` es una anotacion de Spring que permite ejecutar un metodo **automaticamente** en intervalos regulares o en momentos especificos, sin necesidad de que ningun cliente haga una peticion HTTP. Es el equivalente a un **cron job** del sistema operativo, pero gestionado dentro de la aplicacion Spring.
+
+En este proyecto, la sincronizacion con la Whoop API se ejecuta automaticamente cada 30 minutos (configurable), descargando datos nuevos y guardandolos en base de datos.
+
+---
+
+## Habilitacion con @EnableScheduling
+
+Para que `@Scheduled` funcione, es obligatorio habilitar el scheduling en la clase principal de la aplicacion.
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/WhoopDavidApiApplication.kt`
+
+```kotlin
+@SpringBootApplication
+@EnableScheduling
+class WhoopDavidApiApplication
+
+fun main(args: Array<String>) {
+    runApplication<WhoopDavidApiApplication>(*args)
+}
+```
+
+**`@EnableScheduling`** le dice a Spring: "busca beans con metodos `@Scheduled` y programalos para ejecutarse automaticamente". Sin esta anotacion, `@Scheduled` se ignora silenciosamente (el metodo nunca se ejecutaria y no habria ningun error ni advertencia).
+
+Spring crea internamente un `TaskScheduler` con un pool de hilos dedicado para ejecutar las tareas programadas. Por defecto usa un solo hilo, lo que significa que las tareas programadas se ejecutan secuencialmente (si una tarea tarda mucho, la siguiente espera).
+
+---
+
+## WhoopDataSyncScheduler: el disparador
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/scheduler/WhoopDataSyncScheduler.kt`
+
+```kotlin
+@Component
+class WhoopDataSyncScheduler(
+    private val whoopSyncService: WhoopSyncService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "\${app.whoop.sync-cron}")
+    fun scheduledSync() {
+        log.info("Ejecutando sincronizacion programada...")
+        try {
+            whoopSyncService.syncAll()
+        } catch (ex: Exception) {
+            log.error("Error en sincronizacion programada: {}", ex.message, ex)
+        }
+    }
+}
+```
+
+Desglose:
+
+1. **`@Component`**: Registra la clase como un bean de Spring. Es necesario porque Spring solo busca `@Scheduled` en beans gestionados por el contenedor.
+
+2. **Inyeccion por constructor**: `WhoopDataSyncScheduler` recibe `WhoopSyncService` via constructor. Esto sigue el principio de **separacion de responsabilidades**: el scheduler solo decide **cuando** ejecutar; el servicio decide **que** ejecutar.
+
+3. **`@Scheduled(cron = ...)`**: Programa el metodo para ejecutarse segun la expresion cron.
+
+### Cron expression externalizada
+
+```kotlin
+@Scheduled(cron = "\${app.whoop.sync-cron}")
+```
+
+La expresion cron **no esta hardcodeada**. Se lee de la propiedad `app.whoop.sync-cron` del YAML. Esto permite cambiar la frecuencia de sincronizacion por perfil:
+
+| Perfil | Archivo | Valor | Significado |
+|---|---|---|---|
+| Base (todos) | `src/main/resources/application.yaml` | `"0 */30 * * * *"` | Cada 30 minutos |
+| demo | `src/main/resources/application-demo.yaml` | `"0 */5 * * * *"` | Cada 5 minutos |
+
+En el perfil `demo`, la sincronizacion es mas frecuente (cada 5 minutos) porque los datos son mock y no hay riesgo de exceder rate limits de la API real.
+
+La sintaxis `"\${...}"` es **SpEL (Spring Expression Language)**. En el codigo Kotlin se escribe `"\${app.whoop.sync-cron}"` (con backslash para escapar el `$` de Kotlin). Spring lo resuelve al valor de la propiedad en tiempo de arranque.
+
+### Formato de cron en Spring (6 campos)
+
+Spring usa expresiones cron de **6 campos** (a diferencia del cron de Linux que usa 5):
+
+```
+┌──────────── segundo (0-59)
+│ ┌────────── minuto (0-59)
+│ │ ┌──────── hora (0-23)
+│ │ │ ┌────── dia del mes (1-31)
+│ │ │ │ ┌──── mes (1-12)
+│ │ │ │ │ ┌── dia de la semana (0-7, donde 0 y 7 = domingo)
+│ │ │ │ │ │
+* * * * * *
+```
+
+**Diferencia con Linux**: Linux no tiene el campo de **segundos**. Spring lo anade como primer campo.
+
+Desglose de la expresion `"0 */30 * * * *"`:
+
+| Campo | Valor | Significado |
+|---|---|---|
+| Segundo | `0` | En el segundo 0 (inicio del minuto) |
+| Minuto | `*/30` | Cada 30 minutos (`*/N` = cada N unidades) |
+| Hora | `*` | Cualquier hora |
+| Dia del mes | `*` | Cualquier dia |
+| Mes | `*` | Cualquier mes |
+| Dia de la semana | `*` | Cualquier dia de la semana |
+
+Resultado: se ejecuta en el minuto 0 y minuto 30 de cada hora. Es decir, a las 00:00, 00:30, 01:00, 01:30, 02:00, etc.
+
+Otros ejemplos utiles:
+
+| Expresion | Significado |
+|---|---|
+| `"0 */5 * * * *"` | Cada 5 minutos (usado en perfil demo) |
+| `"0 0 6 * * *"` | Todos los dias a las 6:00 AM |
+| `"0 0 */2 * * *"` | Cada 2 horas |
+| `"0 0 8 * * MON-FRI"` | Lunes a viernes a las 8:00 AM |
+| `"0 0 0 1 * *"` | El dia 1 de cada mes a medianoche |
+
+### Manejo de errores en el scheduler
+
+```kotlin
+try {
+    whoopSyncService.syncAll()
+} catch (ex: Exception) {
+    log.error("Error en sincronizacion programada: {}", ex.message, ex)
+}
+```
+
+El `try-catch` es **critico** en un metodo `@Scheduled`. Si una excepcion no capturada escapa del metodo, Spring cancela las ejecuciones futuras de ese metodo programado. Es decir, si una sincronizacion falla sin try-catch, nunca mas se volveria a ejecutar hasta reiniciar la aplicacion.
+
+Con el try-catch, el error se registra en los logs pero el scheduler continua programado para la siguiente ejecucion.
+
+---
+
+## WhoopSyncService: la logica de sincronizacion
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/service/WhoopSyncService.kt`
+
+### Sincronizacion incremental
+
+La estrategia de sincronizacion es **incremental**: en vez de descargar todos los datos de Whoop cada vez, solo se piden los datos **posteriores al ultimo registro guardado**.
+
+```kotlin
+@Service
+class WhoopSyncService(
+    private val whoopApiClient: WhoopApiClient,
+    private val cycleRepository: CycleRepository,
+    private val recoveryRepository: RecoveryRepository,
+    private val sleepRepository: SleepRepository,
+    private val workoutRepository: WorkoutRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun syncAll() {
+        log.info("Iniciando sincronizacion completa con Whoop API...")
+        val start = System.currentTimeMillis()
+
+        syncCycles()
+        syncRecoveries()
+        syncSleeps()
+        syncWorkouts()
+
+        val elapsed = System.currentTimeMillis() - start
+        log.info("Sincronizacion completa en {} ms", elapsed)
+    }
+```
+
+El metodo `syncAll()` llama a los 4 metodos de sincronizacion secuencialmente y mide el tiempo total. Se usa `System.currentTimeMillis()` para calcular la duracion.
+
+El metodo `syncCycles()` muestra el patron completo:
+
+```kotlin
+private fun syncCycles() {
+    try {
+        // Sincronizacion incremental: obtener solo datos nuevos
+        val lastUpdated = cycleRepository.findTopByOrderByUpdatedAtDesc()?.updatedAt
+        val records = whoopApiClient.getAllCycles(start = lastUpdated)
+        var saved = 0
+        var skipped = 0
+
+        for (record in records) {
+            try {
+                val cycle = mapToCycle(record)
+                cycleRepository.save(cycle)
+                saved++
+            } catch (ex: IllegalArgumentException) {
+                log.warn("Saltando cycle con datos inválidos: {}", ex.message)
+                skipped++
+            }
+        }
+
+        log.info("Cycles sincronizados: {} nuevos/actualizados, {} saltados", saved, skipped)
+    } catch (ex: Exception) {
+        log.error("Error sincronizando cycles: {}", ex.message, ex)
+    }
+}
+```
+
+Paso a paso:
+
+1. **`cycleRepository.findTopByOrderByUpdatedAtDesc()?.updatedAt`**: Busca el cycle mas reciente en la base de datos y obtiene su campo `updatedAt`. Si la base de datos esta vacia, devuelve `null` (primera sincronizacion).
+
+2. **`whoopApiClient.getAllCycles(start = lastUpdated)`**: Pide a la Whoop API todos los cycles desde la fecha `lastUpdated`. Si es `null` (primera vez), Whoop devuelve todo el historico.
+
+3. **Bucle de guardado con try-catch interno**: Cada registro se mapea y guarda individualmente. Si un registro tiene datos invalidos (por ejemplo, falta el campo `start`), `mapToCycle` lanza `IllegalArgumentException` y ese registro se salta. Los demas se siguen procesando.
+
+4. **`cycleRepository.save(cycle)`**: JPA `save()` hace un **upsert**: si ya existe un registro con el mismo `id`, lo actualiza. Si no existe, lo inserta. Esto permite reprocesar registros que se hayan actualizado en Whoop.
+
+5. **Contadores `saved` y `skipped`**: Se registran en los logs para monitorizar la salud de la sincronizacion.
+
+Los metodos `syncRecoveries()`, `syncSleeps()` y `syncWorkouts()` siguen exactamente el mismo patron. La unica diferencia es el repositorio y el metodo de mapeo que usan.
+
+### Independencia entre sincronizaciones
+
+Cada metodo `syncXxx()` tiene su propio `try-catch` externo:
+
+```kotlin
+fun syncAll() {
+    syncCycles()       // Si falla, los demas siguen
+    syncRecoveries()   // Si falla, los demas siguen
+    syncSleeps()       // Si falla, los demas siguen
+    syncWorkouts()     // Si falla, los demas siguen
+}
+```
+
+Si `syncCycles()` falla (por ejemplo, Whoop devuelve error 500 para cycles), la excepcion se captura dentro de `syncCycles()` y las sincronizaciones de recoveries, sleeps y workouts se ejecutan normalmente. Este diseno evita que un fallo parcial pierda toda la sincronizacion.
+
+### Mapeo JSON a entidades
+
+La Whoop API devuelve JSON como `Map<String, Any?>`. El mapeo a entidades JPA se hace manualmente con safe casts de Kotlin.
+
+Ejemplo completo con `mapToCycle()`:
+
+```kotlin
+private fun mapToCycle(record: Map<String, Any?>): WhoopCycle {
+    val score = record["score"] as? Map<*, *>
+    return WhoopCycle(
+        id = (record["id"] as Number).toLong(),
+        userId = (record["user_id"] as Number).toLong(),
+        createdAt = parseInstant(record["created_at"]),
+        updatedAt = parseInstant(record["updated_at"]),
+        start = requireNotNull(parseInstant(record["start"])) {
+            "Campo 'start' requerido en cycle (id=${record["id"] ?: "desconocido"})"
+        },
+        end = parseInstant(record["end"]),
+        timezoneOffset = record["timezone_offset"] as? String,
+        scoreState = record["score_state"] as? String ?: "PENDING_SCORE",
+        strain = (score?.get("strain") as? Number)?.toFloat(),
+        kilojoule = (score?.get("kilojoule") as? Number)?.toFloat(),
+        averageHeartRate = (score?.get("average_heart_rate") as? Number)?.toInt(),
+        maxHeartRate = (score?.get("max_heart_rate") as? Number)?.toInt()
+    )
+}
+```
+
+**Tecnicas de Kotlin usadas:**
+
+| Expresion | Que hace | Cuando se usa |
+|---|---|---|
+| `as Number` | Cast **inseguro**. Lanza `ClassCastException` si no es un `Number` | Campos obligatorios como `id` |
+| `as? Number` | Cast **seguro** (safe cast). Devuelve `null` si no se puede convertir | Campos opcionales como `strain` |
+| `as? Map<*, *>` | Safe cast a un Map generico. Se usa para objetos JSON anidados | El campo `score` es un objeto JSON anidado |
+| `?.toFloat()` | Operador de llamada segura. Solo llama `toFloat()` si no es `null` | Conversion encadenada tras safe cast |
+| `?: "PENDING_SCORE"` | Operador Elvis. Si el valor es `null`, usa el valor por defecto | Campos con valor por defecto |
+
+**Por que `as Number` y no `as Long` directamente?** Jackson (el deserializador JSON) convierte numeros JSON a diferentes tipos Java segun su tamano: `Integer` para numeros pequenos, `Long` para grandes. Usando `Number` (la clase padre de todos los tipos numericos en Java), se acepta cualquier tipo numerico y luego se convierte con `.toLong()`.
+
+**Campos anidados (score)**: La Whoop API devuelve el score como un objeto JSON anidado. Primero se extrae el mapa del score y luego se acceden sus campos:
+
+```kotlin
+val score = record["score"] as? Map<*, *>   // Puede ser null si no hay score
+// ...
+strain = (score?.get("strain") as? Number)?.toFloat()
+// score?         -> si score es null, toda la expresion es null
+// .get("strain") -> obtiene el valor de la clave "strain"
+// as? Number     -> safe cast a Number
+// ?.toFloat()    -> convierte a Float si no es null
+```
+
+### parseInstant(): conversion segura de String a Instant
+
+```kotlin
+private fun parseInstant(value: Any?): Instant? {
+    return when (value) {
+        is String -> try { Instant.parse(value) } catch (_: Exception) { null }
+        else -> null
+    }
+}
+```
+
+Esta funcion utilitaria convierte un valor JSON (que puede ser `String`, `null`, u otro tipo) a un `Instant` de Java.
+
+- **`when (value)`**: Expresion when de Kotlin (equivalente a switch en otros lenguajes).
+- **`is String`**: Verifica que el valor sea un String. Si no lo es, devuelve `null`.
+- **`Instant.parse(value)`**: Parsea un String ISO-8601 (como `"2024-12-15T10:30:00.000Z"`) a un `Instant`.
+- **`catch (_: Exception) { null }`**: Si el String no tiene formato ISO-8601 valido, devuelve `null` en vez de lanzar excepcion. El `_` indica que la excepcion se descarta (no se necesita su contenido).
+
+### requireNotNull(): validacion de campos obligatorios
+
+```kotlin
+start = requireNotNull(parseInstant(record["start"])) {
+    "Campo 'start' requerido en cycle (id=${record["id"] ?: "desconocido"})"
+},
+```
+
+`requireNotNull()` es una funcion estandar de Kotlin que lanza `IllegalArgumentException` si el valor es `null`. Es la forma idiomatica de validar precondiciones en Kotlin.
+
+- Si `parseInstant(record["start"])` devuelve `null` (el campo no existe o tiene formato invalido), se lanza `IllegalArgumentException` con el mensaje proporcionado.
+- Ese `IllegalArgumentException` es capturado por el `try-catch` en `syncCycles()`, que salta ese registro y continua con el siguiente.
+- El mensaje incluye el `id` del registro para facilitar el debug: `"Campo 'start' requerido en cycle (id=1005)"`.
+
+---
+
+## Flujo completo de una sincronizacion
+
+```
+[Cada 30 min]
+    │
+    ▼
+WhoopDataSyncScheduler.scheduledSync()
+    │
+    ▼
+WhoopSyncService.syncAll()
+    │
+    ├─> syncCycles()
+    │     ├─ cycleRepository.findTopByOrderByUpdatedAtDesc()?.updatedAt → "2024-12-15T10:00:00Z"
+    │     ├─ whoopApiClient.getAllCycles(start = "2024-12-15T10:00:00Z")
+    │     │    ├─ GET /developer/v1/cycle?limit=25&start=2024-12-15T10:00:00Z
+    │     │    │   → { records: [...15 registros...], next_token: null }
+    │     │    └─ return 15 registros
+    │     ├─ Para cada registro: mapToCycle() → cycleRepository.save()
+    │     └─ Log: "Cycles sincronizados: 15 nuevos/actualizados, 0 saltados"
+    │
+    ├─> syncRecoveries()
+    │     └─ (mismo patron)
+    │
+    ├─> syncSleeps()
+    │     └─ (mismo patron)
+    │
+    └─> syncWorkouts()
+          └─ (mismo patron)
+    │
+    ▼
+Log: "Sincronizacion completa en 2345 ms"
+```
+
+Primera ejecucion (base de datos vacia):
+- `findTopByOrderByUpdatedAtDesc()` devuelve `null`
+- `getAllCycles(start = null)` pide **todo** el historico
+- Puede haber multiples paginas (bucle do-while con `next_token`)
+
+Ejecuciones posteriores:
+- Se obtiene la fecha del ultimo registro guardado
+- Solo se piden datos mas recientes
+- Normalmente son pocos registros (0-2 por cada tipo en 30 minutos)
+
+---
+
+## Documentacion oficial
+
+- [Spring @Scheduled](https://docs.spring.io/spring-framework/reference/integration/scheduling.html) - Documentacion oficial de tareas programadas
+- [Spring Cron Expressions](https://docs.spring.io/spring-framework/reference/integration/scheduling.html#scheduling-cron-expression) - Formato de cron de Spring (6 campos)
+- [Kotlin requireNotNull](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/require-not-null.html) - Documentacion de requireNotNull
+- [Kotlin Safe Casts](https://kotlinlang.org/docs/typecasts.html#safe-nullable-cast-operator) - Operador as? de Kotlin
+- [Java Instant.parse](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/time/Instant.html#parse(java.lang.CharSequence)) - Parseo de timestamps ISO-8601

--- a/docs/11-perfiles.md
+++ b/docs/11-perfiles.md
@@ -1,0 +1,547 @@
+# 11 - Perfiles de Spring
+
+## Tabla de contenidos
+
+- [Que son los perfiles de Spring?](#que-son-los-perfiles-de-spring)
+- [Como se activan los perfiles](#como-se-activan-los-perfiles)
+- [Carga de configuracion: base + perfil](#carga-de-configuracion-base--perfil)
+- [Anotaciones de perfil en beans](#anotaciones-de-perfil-en-beans)
+- [Los 3 perfiles del proyecto](#los-3-perfiles-del-proyecto)
+  - [Perfil dev (desarrollo)](#perfil-dev-desarrollo)
+  - [Perfil prod (produccion)](#perfil-prod-produccion)
+  - [Perfil demo (testing sin API keys reales)](#perfil-demo-testing-sin-api-keys-reales)
+- [Beans exclusivos del perfil demo](#beans-exclusivos-del-perfil-demo)
+  - [MockWhoopApiController](#mockwhoopapicntroller)
+  - [MockWhoopDataGenerator](#mockwhoopdatagenerator)
+  - [DemoTokenSeeder y CommandLineRunner](#demotokenseeder-y-commandlinerunner)
+  - [DemoWhoopTokenManager y @Primary](#demowhooptokenmanager-y-primary)
+- [Tabla resumen de diferencias entre perfiles](#tabla-resumen-de-diferencias-entre-perfiles)
+- [Documentacion oficial](#documentacion-oficial)
+
+---
+
+## Que son los perfiles de Spring?
+
+Los perfiles de Spring permiten tener **diferentes configuraciones** para diferentes entornos (desarrollo, produccion, testing) dentro de la misma aplicacion. En vez de mantener multiples versiones del codigo o multiples archivos de configuracion sueltos, Spring permite activar/desactivar componentes y propiedades segun el perfil activo.
+
+Un perfil afecta dos cosas:
+
+1. **Propiedades de configuracion**: Que archivo YAML se carga (base de datos, URLs, credenciales, etc.)
+2. **Beans de Spring**: Que clases se registran en el contenedor (se pueden crear beans solo para ciertos perfiles)
+
+---
+
+## Como se activan los perfiles
+
+Hay varias formas de activar un perfil. En orden de prioridad (de mayor a menor):
+
+| Metodo | Ejemplo | Donde se usa |
+|---|---|---|
+| **Variable de entorno** | `SPRING_PROFILES_ACTIVE=prod` | Produccion (Kubernetes, Docker) |
+| **Argumento de JVM** | `-Dspring.profiles.active=dev` | IDE (IntelliJ, Eclipse) |
+| **Argumento de linea de comandos** | `--spring.profiles.active=dev,demo` | Terminal, scripts |
+| **En application.yaml** | `spring.profiles.active: dev` | No recomendado (hardcodea el perfil) |
+
+En este proyecto:
+
+- **Desarrollo local**: Se ejecuta con `--spring.profiles.active=dev` o `SPRING_PROFILES_ACTIVE=dev`
+- **Produccion (Kubernetes)**: La variable de entorno `SPRING_PROFILES_ACTIVE=prod` se define en el manifiesto de Kubernetes
+- **Demo**: Se ejecuta con `--spring.profiles.active=dev,demo` (demo se combina con dev para tener H2)
+
+Se pueden activar **multiples perfiles** separandolos por coma: `dev,demo` activa ambos perfiles simultaneamente.
+
+---
+
+## Carga de configuracion: base + perfil
+
+Spring carga los archivos YAML en un orden especifico y los **fusiona** (merge):
+
+```
+1. application.yaml           ← Se carga SIEMPRE (configuracion base)
+2. application-{perfil}.yaml  ← Se carga SOLO si el perfil esta activo
+```
+
+**Las propiedades del perfil sobreescriben las del base.** Las que no se redefinen en el perfil mantienen el valor base.
+
+Ejemplo concreto con `app.whoop.sync-cron`:
+
+**`src/main/resources/application.yaml`** (base):
+```yaml
+app:
+  whoop:
+    sync-cron: "0 */30 * * * *"    # Cada 30 minutos
+```
+
+**`src/main/resources/application-demo.yaml`** (perfil demo):
+```yaml
+app:
+  whoop:
+    sync-cron: "0 */5 * * * *"     # Cada 5 minutos (sobreescribe el base)
+```
+
+| Perfil activo | Valor de `app.whoop.sync-cron` | Fuente |
+|---|---|---|
+| `dev` | `"0 */30 * * * *"` | application.yaml (base, no sobreescrito) |
+| `prod` | `"0 */30 * * * *"` | application.yaml (base, no sobreescrito) |
+| `demo` | `"0 */5 * * * *"` | application-demo.yaml (sobreescribe base) |
+
+Lo mismo ocurre con `app.whoop.base-url`:
+
+| Perfil activo | Valor | Fuente |
+|---|---|---|
+| `dev` o `prod` | `https://api.prod.whoop.com` | application.yaml (base) |
+| `demo` | `http://localhost:8080/mock` | application-demo.yaml (sobreescribe) |
+
+---
+
+## Anotaciones de perfil en beans
+
+La anotacion `@Profile` controla en que perfiles se registra un bean:
+
+| Anotacion | Significado | Ejemplo |
+|---|---|---|
+| `@Profile("demo")` | Solo se crea cuando el perfil `demo` esta activo | `DemoWhoopTokenManager` |
+| `@Profile("!demo")` | Se crea en todos los perfiles **excepto** `demo` | `WhoopTokenManager` |
+| `@Profile("dev")` | Solo se crea cuando el perfil `dev` esta activo | (no usado en este proyecto) |
+| Sin `@Profile` | Se crea siempre, independientemente del perfil | `WhoopApiClient`, `WhoopSyncService`, etc. |
+
+El operador `!` (negacion) es clave para el patron Strategy que usa este proyecto con `TokenManager`:
+
+```
+Perfil activo  │  @Profile("!demo")         │  @Profile("demo")
+               │  WhoopTokenManager          │  DemoWhoopTokenManager
+───────────────┼─────────────────────────────┼──────────────────────
+dev            │  SE CREA                    │  NO se crea
+prod           │  SE CREA                    │  NO se crea
+demo           │  NO se crea                │  SE CREA
+dev,demo       │  NO se crea (demo activo)  │  SE CREA
+```
+
+---
+
+## Los 3 perfiles del proyecto
+
+### Perfil dev (desarrollo)
+
+**Archivo**: `src/main/resources/application-dev.yaml`
+
+```yaml
+spring:
+  # H2 in-memory database
+  datasource:
+    url: jdbc:h2:mem:whoop_dev;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # H2 Console
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  # JPA dev settings
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  # Disable OAuth2 auto-config in dev (tokens managed manually)
+  security:
+    oauth2:
+      client:
+        registration:
+          whoop:
+            client-id: ${WHOOP_CLIENT_ID:dev-client-id}
+            client-secret: ${WHOOP_CLIENT_SECRET:dev-client-secret}
+
+# App-specific dev config
+app:
+  security:
+    # Clave de cifrado para desarrollo/testing (NO usar en produccion)
+    encryption-key: ${ENCRYPTION_KEY:YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU=}
+
+logging:
+  level:
+    com.example.whoopdavidapi: DEBUG
+    org.springframework.security: DEBUG
+    org.hibernate.SQL: DEBUG
+```
+
+Puntos clave del perfil dev:
+
+**Base de datos H2 in-memory**:
+- `jdbc:h2:mem:whoop_dev` crea una base de datos **en memoria**. Se crea al arrancar y se destruye al parar. No necesita instalar nada.
+- `DB_CLOSE_DELAY=-1` evita que H2 cierre la base de datos cuando no hay conexiones activas.
+- `DB_CLOSE_ON_EXIT=FALSE` evita que H2 cierre la base de datos al salir de la JVM (necesario para tests).
+- `driver-class-name: org.h2.Driver` indica el driver JDBC para H2.
+
+**`ddl-auto: update`**:
+Hibernate **crea y modifica** las tablas automaticamente basandose en las entidades `@Entity`. Si se anade un campo a `WhoopCycle`, Hibernate anade la columna a la tabla. Ideal para desarrollo rapido, pero **peligroso en produccion** (podria hacer cambios no deseados).
+
+**Consola H2**:
+- `h2.console.enabled: true` habilita una interfaz web para consultar la base de datos H2.
+- Accesible en `http://localhost:8080/h2-console`.
+- Util para verificar que los datos se estan guardando correctamente durante desarrollo.
+
+**`show-sql: true` y `format_sql: true`**:
+Muestra las queries SQL que Hibernate genera en la consola, formateadas para legibilidad. Ejemplo de output:
+```sql
+select
+    wc.id,
+    wc.user_id,
+    wc.start_time,
+    ...
+from
+    whoop_cycles wc
+order by
+    wc.updated_at desc
+limit 1
+```
+
+**Clave de cifrado con default**:
+`${ENCRYPTION_KEY:YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU=}` proporciona una clave por defecto para desarrollo. En produccion, la variable `ENCRYPTION_KEY` debe estar definida sin default (ver perfil prod).
+
+**OAuth2 client-id/secret con defaults**:
+`${WHOOP_CLIENT_ID:dev-client-id}` permite arrancar sin las variables de entorno reales de Whoop. Esto es util en desarrollo cuando no se necesita conectar a la API real.
+
+### Perfil prod (produccion)
+
+**Archivo**: `src/main/resources/application-prod.yaml`
+
+```yaml
+spring:
+  # PostgreSQL
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      maximum-pool-size: 10
+      minimum-idle: 2
+      pool-name: WhoopHikariPool
+
+  # H2 Console disabled in prod
+  h2:
+    console:
+      enabled: false
+
+  # JPA prod settings
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+logging:
+  level:
+    root: INFO
+    com.example.whoopdavidapi: INFO
+    org.hibernate.SQL: WARN
+```
+
+Puntos clave del perfil prod:
+
+**PostgreSQL con HikariCP**:
+- `${DATABASE_URL}`, `${DB_USERNAME}`, `${DB_PASSWORD}`: Sin valores por defecto. La aplicacion **no arranca** si estas variables no estan definidas. Esto es intencional: obliga a configurar las credenciales correctamente.
+- `driver-class-name: org.postgresql.Driver`: Driver JDBC para PostgreSQL.
+- **HikariCP** es el pool de conexiones de base de datos por defecto de Spring Boot. Reutiliza conexiones en vez de abrir/cerrar una nueva para cada query:
+
+| Propiedad | Valor | Significado |
+|---|---|---|
+| `maximum-pool-size` | `10` | Maximo 10 conexiones simultaneas a PostgreSQL |
+| `minimum-idle` | `2` | Mantiene al menos 2 conexiones abiertas siempre (para respuesta rapida) |
+| `connection-timeout` | `30000` | 30 segundos max para obtener una conexion del pool |
+| `idle-timeout` | `600000` | 10 minutos: una conexion inactiva se cierra |
+| `max-lifetime` | `1800000` | 30 minutos: vida maxima de una conexion (se recicla para evitar leaks) |
+
+**`ddl-auto: validate`**:
+A diferencia de `update` en dev, `validate` **no modifica** la base de datos. Solo verifica que las tablas existentes coincidan con las entidades JPA. Si no coinciden, la aplicacion **no arranca**. Esto protege contra cambios accidentales en produccion. Los cambios de esquema deben hacerse con herramientas de migracion (como Flyway o Liquibase).
+
+**Logging reducido**:
+- `com.example.whoopdavidapi: INFO` (en vez de DEBUG)
+- `org.hibernate.SQL: WARN` (no muestra queries SQL)
+- Menos logs = mejor rendimiento y menos almacenamiento en produccion.
+
+### Perfil demo (testing sin API keys reales)
+
+**Archivo**: `src/main/resources/application-demo.yaml`
+
+```yaml
+# Perfil demo: mock Whoop API en localhost, sin API keys reales
+app:
+  whoop:
+    base-url: http://localhost:8080/mock
+    sync-cron: "0 */5 * * * *"
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          whoop:
+            client-id: demo-client-id
+            client-secret: demo-client-secret
+
+logging:
+  level:
+    com.example.whoopdavidapi.mock: DEBUG
+```
+
+El perfil `demo` esta disenado para ejecutar la aplicacion **completa** sin necesitar credenciales reales de la Whoop API. Es ideal para:
+
+- Probar la aplicacion por primera vez
+- Hacer demostraciones
+- Desarrollo de frontend (Power BI) sin depender de la API real
+
+**`base-url: http://localhost:8080/mock`**:
+Redirige todas las peticiones HTTP del `WhoopApiClient` al controlador mock que corre dentro de la propia aplicacion (en `/mock/developer/v1/...`). Es decir, la aplicacion se llama a si misma.
+
+**`sync-cron: "0 */5 * * * *"`**:
+Sincronizacion cada 5 minutos (en vez de 30). Como los datos son mock, no hay riesgo de saturar ninguna API.
+
+**Credenciales demo**: `demo-client-id` y `demo-client-secret` son valores falsos. El controlador mock no valida credenciales.
+
+El perfil `demo` se usa normalmente **combinado con dev**: `--spring.profiles.active=dev,demo`. Asi se tiene H2 in-memory (de dev) + API mock (de demo).
+
+---
+
+## Beans exclusivos del perfil demo
+
+El perfil demo activa 4 clases anotadas con `@Profile("demo")`, ubicadas en el paquete `mock/`.
+
+### MockWhoopApiController
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/mock/MockWhoopApiController.kt`
+
+```kotlin
+@RestController
+@Profile("demo")
+@RequestMapping("/mock/developer/v1")
+class MockWhoopApiController(
+    private val dataGenerator: MockWhoopDataGenerator
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/cycle")
+    fun getCycles(
+        @RequestParam(defaultValue = "25") limit: Int,
+        @RequestParam(required = false) nextToken: String?,
+        @RequestParam(required = false) start: String?,
+        @RequestParam(required = false) end: String?
+    ): Map<String, Any?> {
+        log.debug("Mock GET /cycle limit={} nextToken={}", limit, nextToken)
+        return paginate(dataGenerator.cycles, limit, nextToken)
+    }
+
+    @GetMapping("/recovery")
+    fun getRecoveries(
+        @RequestParam(defaultValue = "25") limit: Int,
+        @RequestParam(required = false) nextToken: String?,
+        @RequestParam(required = false) start: String?,
+        @RequestParam(required = false) end: String?
+    ): Map<String, Any?> {
+        log.debug("Mock GET /recovery limit={} nextToken={}", limit, nextToken)
+        return paginate(dataGenerator.recoveries, limit, nextToken)
+    }
+
+    @GetMapping("/activity/sleep")
+    fun getSleeps(
+        @RequestParam(defaultValue = "25") limit: Int,
+        @RequestParam(required = false) nextToken: String?,
+        @RequestParam(required = false) start: String?,
+        @RequestParam(required = false) end: String?
+    ): Map<String, Any?> {
+        log.debug("Mock GET /activity/sleep limit={} nextToken={}", limit, nextToken)
+        return paginate(dataGenerator.sleeps, limit, nextToken)
+    }
+
+    @GetMapping("/activity/workout")
+    fun getWorkouts(
+        @RequestParam(defaultValue = "25") limit: Int,
+        @RequestParam(required = false) nextToken: String?,
+        @RequestParam(required = false) start: String?,
+        @RequestParam(required = false) end: String?
+    ): Map<String, Any?> {
+        log.debug("Mock GET /activity/workout limit={} nextToken={}", limit, nextToken)
+        return paginate(dataGenerator.workouts, limit, nextToken)
+    }
+
+    @GetMapping("/user/profile/basic")
+    fun getProfile(): Map<String, Any?> {
+        log.debug("Mock GET /user/profile/basic")
+        return dataGenerator.profile
+    }
+
+    private fun paginate(
+        allRecords: List<Map<String, Any?>>,
+        limit: Int,
+        nextToken: String?
+    ): Map<String, Any?> {
+        val offset = nextToken?.toIntOrNull() ?: 0
+        val effectiveLimit = limit.coerceIn(1, 25)
+        val page = allRecords.drop(offset).take(effectiveLimit)
+        val nextOffset = offset + page.size
+
+        return mapOf(
+            "records" to page,
+            "next_token" to if (nextOffset < allRecords.size) nextOffset.toString() else null
+        )
+    }
+}
+```
+
+Este controlador **simula la Whoop API** dentro de la propia aplicacion. Los endpoints replican la misma estructura que la API real:
+
+- Mismos paths: `/developer/v1/cycle`, `/developer/v1/recovery`, `/developer/v1/activity/sleep`, `/developer/v1/activity/workout`, `/developer/v1/user/profile/basic`
+- Mismos parametros: `limit`, `nextToken`, `start`, `end`
+- Misma estructura de respuesta: `{ "records": [...], "next_token": "..." }`
+
+El `@RequestMapping("/mock/developer/v1")` anade el prefijo `/mock` para no colisionar con los endpoints reales de la aplicacion (que estan en `/api/v1/...`).
+
+**Logica de paginacion mock**: La funcion `paginate()` simula la paginacion real de Whoop. Usa `nextToken` como un offset numerico (indice en la lista de registros), devuelve `limit` registros desde ese offset, y genera un `next_token` si quedan mas registros.
+
+El `WhoopApiClient` no sabe que esta llamando a un mock. Para el, es la misma URL base (configurada como `http://localhost:8080/mock` via YAML) con los mismos endpoints. Esto es posible porque el `base-url` se inyecta desde la configuracion.
+
+### MockWhoopDataGenerator
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/mock/MockWhoopDataGenerator.kt`
+
+```kotlin
+@Component
+@Profile("demo")
+class MockWhoopDataGenerator {
+
+    private val random = Random(42)
+    private val userId = 123456L
+    private val days = 30
+
+    val cycles: List<Map<String, Any?>> by lazy { generateCycles() }
+    val recoveries: List<Map<String, Any?>> by lazy { generateRecoveries() }
+    val sleeps: List<Map<String, Any?>> by lazy { generateSleeps() }
+    val workouts: List<Map<String, Any?>> by lazy { generateWorkouts() }
+
+    val profile: Map<String, Any?> = mapOf(
+        "user_id" to userId,
+        "email" to "david.demo@whoop.com",
+        "first_name" to "David",
+        "last_name" to "Demo"
+    )
+    // ... metodos generateCycles(), generateRecoveries(), etc.
+}
+```
+
+Caracteristicas importantes:
+
+- **`Random(42)`**: Se usa una seed determinista (`42`). Esto significa que los datos generados son **siempre los mismos** en cada ejecucion. Esto facilita el testing reproducible y las demostraciones consistentes.
+- **`by lazy { ... }`**: Delegacion `lazy` de Kotlin. Los datos no se generan al crear el bean, sino la **primera vez** que se accede a la propiedad. Despues se cachean (no se vuelven a generar).
+- **30 dias de datos**: Se generan cycles, recoveries, sleeps y workouts para los ultimos 30 dias, con valores realistas (strain entre 4-21, recovery score entre 20-99, etc.).
+- **Workouts con probabilidad del 70%**: Para simular que no todos los dias tienen entrenamiento, se usa `if (random.nextFloat() > 0.70f) continue` (aproximadamente 4-5 workouts por semana).
+
+### DemoTokenSeeder y CommandLineRunner
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/mock/DemoTokenSeeder.kt`
+
+```kotlin
+@Component
+@Profile("demo")
+class DemoTokenSeeder(
+    private val tokenRepository: OAuthTokenRepository
+) : CommandLineRunner {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun run(vararg args: String) {
+        if (tokenRepository.count() == 0L) {
+            val token = OAuthTokenEntity(
+                accessToken = "demo-access-token",
+                refreshToken = "demo-refresh-token",
+                tokenType = "Bearer",
+                expiresAt = Instant.now().plusSeconds(86400),
+                scope = "offline,read:profile,read:cycles,read:recovery,read:sleep,read:workout",
+                createdAt = Instant.now(),
+                updatedAt = Instant.now()
+            )
+            tokenRepository.save(token)
+            log.info("Token OAuth2 demo insertado en BD")
+        }
+    }
+}
+```
+
+**`CommandLineRunner`** es una interfaz de Spring Boot que permite ejecutar codigo **justo despues de que la aplicacion arranca**. El metodo `run()` se invoca automaticamente una sola vez al inicio.
+
+En este caso, inserta un token OAuth2 falso en la base de datos para que la aplicacion funcione sin haber pasado por el flujo real de autorizacion de Whoop. La condicion `if (tokenRepository.count() == 0L)` evita insertar duplicados si se reinicia la aplicacion sin limpiar la base de datos.
+
+El `accessToken` es `"demo-access-token"`, el mismo valor que devuelve `DemoWhoopTokenManager.getValidAccessToken()`. El `expiresAt` se configura a 24 horas en el futuro (`86400` segundos) para que no expire durante una sesion de desarrollo normal.
+
+### DemoWhoopTokenManager y @Primary
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/mock/DemoWhoopTokenManager.kt`
+
+```kotlin
+@Component
+@Profile("demo")
+@Primary
+class DemoWhoopTokenManager : TokenManager {
+
+    override fun getValidAccessToken(): String = "demo-access-token"
+}
+```
+
+Dos anotaciones trabajan juntas aqui:
+
+**`@Profile("demo")`**: Este bean solo existe cuando el perfil `demo` esta activo.
+
+**`@Primary`**: Si Spring encuentra **mas de un bean** del mismo tipo (`TokenManager`), usa el marcado como `@Primary`. Es una medida de seguridad: aunque `@Profile("!demo")` en `WhoopTokenManager` deberia impedir que ambos coexistan, `@Primary` garantiza que en caso de conflicto, el mock gana.
+
+La contraparte es `WhoopTokenManager`:
+
+**Archivo**: `src/main/kotlin/com/example/whoopdavidapi/client/WhoopTokenManager.kt`
+
+```kotlin
+@Component
+@org.springframework.context.annotation.Profile("!demo")
+class WhoopTokenManager(...) : TokenManager {
+```
+
+**`@Profile("!demo")`** significa "activo en cualquier perfil que NO sea demo". Es la negacion logica. Si el perfil activo es `dev`, `prod`, o cualquier otro que no sea `demo`, este bean se crea. Si el perfil activo incluye `demo`, este bean no se crea.
+
+---
+
+## Tabla resumen de diferencias entre perfiles
+
+| Aspecto | dev | prod | demo (con dev) |
+|---|---|---|---|
+| **Base de datos** | H2 in-memory | PostgreSQL | H2 in-memory |
+| **DDL** | `update` (auto-crear) | `validate` (solo verificar) | `update` (auto-crear) |
+| **Consola H2** | Habilitada | Deshabilitada | Habilitada |
+| **SQL en logs** | Si (DEBUG) | No (WARN) | Si (DEBUG) |
+| **URL Whoop** | `https://api.prod.whoop.com` | `https://api.prod.whoop.com` | `http://localhost:8080/mock` |
+| **Sync cron** | Cada 30 min | Cada 30 min | Cada 5 min |
+| **TokenManager** | `WhoopTokenManager` (real) | `WhoopTokenManager` (real) | `DemoWhoopTokenManager` (mock) |
+| **API keys** | Defaults (`dev-client-id`) | Requeridas (sin default) | Valores demo |
+| **Encryption key** | Default hardcodeado | Requerida (sin default) | Default hardcodeado |
+| **MockWhoopApiController** | No existe | No existe | Activo en `/mock/...` |
+| **DemoTokenSeeder** | No existe | No existe | Inserta token al arrancar |
+| **Log level** | DEBUG | INFO | DEBUG + mock: DEBUG |
+
+---
+
+## Documentacion oficial
+
+- [Spring Boot Profiles](https://docs.spring.io/spring-boot/reference/features/profiles.html) - Documentacion oficial de perfiles
+- [Spring @Profile](https://docs.spring.io/spring-framework/reference/core/beans/environment.html#beans-definition-profiles) - Anotacion @Profile
+- [Spring Boot External Configuration](https://docs.spring.io/spring-boot/reference/features/external-config.html) - Orden de precedencia de propiedades
+- [Spring Boot CommandLineRunner](https://docs.spring.io/spring-boot/api/java/org/springframework/boot/CommandLineRunner.html) - Ejecucion de codigo al arrancar
+- [HikariCP Configuration](https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby) - Configuracion del pool de conexiones

--- a/docs/12-testing.md
+++ b/docs/12-testing.md
@@ -1,0 +1,649 @@
+# 12. Testing en Spring Boot
+
+## Indice
+
+1. [Que es el testing en Spring Boot](#1-que-es-el-testing-en-spring-boot)
+2. [La piramide de testing](#2-la-piramide-de-testing)
+3. [Donde se usa en nuestro proyecto](#3-donde-se-usa-en-nuestro-proyecto)
+4. [Por que testeamos asi](#4-por-que-testeamos-asi)
+5. [Anotaciones clave explicadas](#5-anotaciones-clave-explicadas)
+6. [Codigo explicado](#6-codigo-explicado)
+7. [Gotchas de Spring Boot 4](#7-gotchas-de-spring-boot-4)
+8. [Configuracion en build.gradle.kts](#8-configuracion-en-buildgradlekts)
+9. [Documentacion oficial](#9-documentacion-oficial)
+
+---
+
+## 1. Que es el testing en Spring Boot
+
+Spring Boot proporciona un framework de testing integrado que permite verificar el comportamiento de tu aplicacion a distintos niveles: desde funciones aisladas (tests unitarios) hasta la aplicacion completa funcionando con base de datos, seguridad y HTTP (tests de integracion).
+
+El framework se basa en **JUnit 5** como motor de ejecucion y ofrece anotaciones especializadas que levantan solo las partes del contexto de Spring que necesitas para cada tipo de test.
+
+---
+
+## 2. La piramide de testing
+
+```
+          /\
+         /  \          Tests E2E (end-to-end)
+        /    \         - App completa desplegada
+       /------\        - Lentos, fragiles, pocos
+      /        \
+     /  Integr. \      Tests de integracion
+    /            \     - @SpringBootTest, @DataJpaTest
+   /--------------\    - Levantan contexto Spring parcial o completo
+  /                \
+ /   Tests Unit.    \  Tests unitarios
+/____________________\ - @ExtendWith(MockitoExtension::class)
+                       - Rapidos, sin Spring, muchos
+```
+
+| Nivel | Velocidad | Contexto Spring | Ejemplo en el proyecto |
+|-------|-----------|-----------------|------------------------|
+| **Unitario** | Muy rapido | No | `CycleServiceTest` |
+| **Integracion (JPA)** | Medio | Solo capa JPA | `CycleRepositoryTest` |
+| **Integracion (Web)** | Medio-lento | Completo + MockMvc | `CycleControllerTest` |
+| **Contexto completo** | Lento | Todo | `WhoopDavidApiApplicationTests` |
+
+**Regla general**: cuanto mas abajo en la piramide, mas tests deberias tener. Los tests unitarios son rapidos y baratos; los de integracion son lentos pero verifican que las piezas encajan.
+
+---
+
+## 3. Donde se usa en nuestro proyecto
+
+Todos los tests estan en `src/test/kotlin/com/example/whoopdavidapi/`:
+
+```
+src/test/kotlin/com/example/whoopdavidapi/
+├── WhoopDavidApiApplicationTests.kt          # Test de carga del contexto
+├── repository/
+│   └── CycleRepositoryTest.kt                # Tests de repositorio JPA
+├── service/
+│   └── CycleServiceTest.kt                   # Tests unitarios del servicio
+└── controller/
+    └── CycleControllerTest.kt                # Tests de integracion HTTP
+```
+
+Se ejecutan con:
+
+```bash
+./gradlew build      # Compila + ejecuta tests
+./gradlew test       # Solo ejecuta tests
+```
+
+---
+
+## 4. Por que testeamos asi
+
+| Decision | Razon |
+|----------|-------|
+| `@ActiveProfiles("dev")` en todos los tests | Usa H2 en memoria en lugar de PostgreSQL real |
+| `@ExtendWith(MockitoExtension::class)` para servicios | No necesitamos Spring para testear logica de negocio pura |
+| `@DataJpaTest` para repositorios | Levanta solo JPA + H2, mucho mas rapido que `@SpringBootTest` |
+| `@SpringBootTest + @AutoConfigureMockMvc` para controllers | Necesitamos seguridad (Basic Auth) y HTTP real para verificar endpoints |
+| `@MockitoBean` para inyectar mocks en tests de integracion | Aisla el controller de sus dependencias reales (servicio, repositorio) |
+| `@Import(TokenEncryptor::class)` en `@DataJpaTest` | `@DataJpaTest` no carga todos los beans, pero `OAuthTokenEntity` necesita `TokenEncryptor` como converter JPA |
+
+---
+
+## 5. Anotaciones clave explicadas
+
+### `@SpringBootTest`
+
+Carga el **contexto completo** de la aplicacion Spring. Es la anotacion mas pesada: levanta todos los beans, la configuracion, la seguridad, JPA, etc.
+
+```kotlin
+@SpringBootTest  // Levanta toda la aplicacion
+@ActiveProfiles("dev")  // Usa application-dev.yaml (H2 en memoria)
+class WhoopDavidApiApplicationTests {
+    @Test
+    fun contextLoads() {
+        // Si este test pasa, toda la configuracion de Spring es correcta
+    }
+}
+```
+
+**Cuando usarla**: para verificar que toda la aplicacion arranca sin errores, o para tests de integracion completos.
+
+### `@DataJpaTest`
+
+Carga **solo la capa JPA**: entidades, repositorios, Hibernate y una base de datos embebida (H2). **No** carga controllers, servicios, seguridad ni nada mas.
+
+```kotlin
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest  // Spring Boot 4
+
+@DataJpaTest
+@Import(TokenEncryptor::class)  // Bean extra necesario para el converter JPA
+@ActiveProfiles("dev")
+class CycleRepositoryTest { ... }
+```
+
+**Cuando usarla**: para testear queries de repositorio, validar que las entidades JPA se mapean bien a la BD, probar paginacion.
+
+### `@WebMvcTest` y `@AutoConfigureMockMvc`
+
+Ambas sirven para testear la capa web (controllers), pero de forma diferente:
+
+- **`@WebMvcTest(CycleController::class)`**: carga SOLO el controller indicado y sus dependencias web. No carga servicios, repositorios, etc. Hay que mockear todo.
+- **`@SpringBootTest + @AutoConfigureMockMvc`**: carga el contexto completo PERO te da un `MockMvc` para hacer peticiones HTTP sin levantar un servidor real.
+
+En nuestro proyecto usamos la segunda opcion:
+
+```kotlin
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc  // Spring Boot 4
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class CycleControllerTest { ... }
+```
+
+**Por que `@SpringBootTest + @AutoConfigureMockMvc` en vez de `@WebMvcTest`**: porque necesitamos que la capa de seguridad (Spring Security con Basic Auth) este cargada y configurada correctamente. `@WebMvcTest` no carga la configuracion de seguridad completa.
+
+### `@MockitoBean` (reemplaza a `@MockBean`)
+
+Inyecta un mock de Mockito **dentro del contexto de Spring**, reemplazando el bean real. Se usa en tests de integracion para aislar el componente bajo test.
+
+```kotlin
+import org.springframework.test.context.bean.override.mockito.MockitoBean  // Spring Boot 4
+
+@MockitoBean
+lateinit var cycleService: CycleService  // Spring inyecta un mock en vez del servicio real
+```
+
+**Diferencia con `@Mock`**: `@Mock` es de Mockito puro (sin Spring). `@MockitoBean` registra el mock en el ApplicationContext de Spring para que los beans que dependan de el reciban el mock.
+
+### `@ExtendWith(MockitoExtension::class)`
+
+Activa Mockito en un test **sin Spring**. Es la forma de hacer tests unitarios puros: rapidos, sin contexto de Spring, solo logica de negocio.
+
+```kotlin
+@ExtendWith(MockitoExtension::class)  // Activa @Mock, @InjectMocks, etc.
+class CycleServiceTest {
+    @Mock lateinit var cycleRepository: CycleRepository    // Mock puro de Mockito
+    @Mock lateinit var cycleMapper: CycleMapper            // Mock puro de Mockito
+    @InjectMocks lateinit var cycleService: CycleService   // Inyecta los mocks arriba
+}
+```
+
+### `MockMvc`
+
+Es una herramienta de Spring que simula peticiones HTTP sin levantar un servidor real. Permite testear controllers, seguridad, serializacion JSON, codigos de respuesta, etc.
+
+```kotlin
+mockMvc.perform(
+    get("/api/v1/cycles")                                // Simula GET /api/v1/cycles
+        .with(httpBasic("powerbi", "changeme"))          // Envia cabecera Basic Auth
+)
+    .andExpect(status().isOk)                            // Verifica HTTP 200
+    .andExpect(jsonPath("$.data").isArray)                // Verifica que $.data es un array
+    .andExpect(jsonPath("$.data[0].id").value(1))        // Verifica el valor del campo
+    .andExpect(jsonPath("$.pagination.hasMore").value(false))
+```
+
+---
+
+## 6. Codigo explicado
+
+### Test 1: Carga del contexto (`WhoopDavidApiApplicationTests.kt`)
+
+**Archivo**: `src/test/kotlin/com/example/whoopdavidapi/WhoopDavidApiApplicationTests.kt`
+
+```kotlin
+package com.example.whoopdavidapi
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("dev")
+class WhoopDavidApiApplicationTests {
+
+    @Test
+    fun contextLoads() {
+    }
+}
+```
+
+**Que hace**: verifica que toda la aplicacion Spring Boot arranca sin errores. Si hay un bean mal configurado, una dependencia circular, un `application.yaml` con errores o cualquier problema de configuracion, este test falla.
+
+**Por que esta vacio**: el test no necesita hacer nada. El simple hecho de que `@SpringBootTest` levante el contexto sin lanzar una excepcion ya verifica que todo esta correcto.
+
+**`@ActiveProfiles("dev")`**: activa el perfil `dev`, que usa H2 en memoria en lugar de PostgreSQL. Asi los tests no necesitan una base de datos externa.
+
+---
+
+### Test 2: Repositorio JPA (`CycleRepositoryTest.kt`)
+
+**Archivo**: `src/test/kotlin/com/example/whoopdavidapi/repository/CycleRepositoryTest.kt`
+
+```kotlin
+package com.example.whoopdavidapi.repository
+
+import com.example.whoopdavidapi.model.entity.WhoopCycle
+import com.example.whoopdavidapi.util.TokenEncryptor
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+
+@DataJpaTest
+@Import(TokenEncryptor::class)
+@ActiveProfiles("dev")
+class CycleRepositoryTest {
+
+    @Autowired
+    lateinit var cycleRepository: CycleRepository
+
+    @Test
+    fun `guardar y recuperar un ciclo`() {
+        val cycle = WhoopCycle(
+            id = 12345L,
+            userId = 1L,
+            start = Instant.parse("2024-01-15T08:00:00Z"),
+            end = Instant.parse("2024-01-16T08:00:00Z"),
+            scoreState = "SCORED",
+            strain = 15.5f,
+            kilojoule = 2500.0f,
+            averageHeartRate = 72,
+            maxHeartRate = 185
+        )
+        cycleRepository.save(cycle)
+
+        val found = cycleRepository.findById(12345L)
+        assertTrue(found.isPresent)
+        assertEquals(15.5f, found.get().strain)
+        assertEquals(72, found.get().averageHeartRate)
+    }
+```
+
+Linea por linea:
+
+- **`@DataJpaTest`**: levanta solo Hibernate + H2. No carga controllers, servicios, seguridad.
+- **`@Import(TokenEncryptor::class)`**: `@DataJpaTest` solo carga los beans JPA. Pero la entidad `OAuthTokenEntity` usa un `@Convert(converter = TokenEncryptorConverter::class)` que necesita `TokenEncryptor`. Sin este `@Import`, el contexto falla al intentar crear la tabla.
+- **`@Autowired lateinit var cycleRepository`**: Spring inyecta el repositorio real (no un mock). Las queries van contra H2 en memoria.
+- **`cycleRepository.save(cycle)`**: ejecuta un `INSERT INTO whoop_cycle ...` contra H2.
+- **`cycleRepository.findById(12345L)`**: ejecuta un `SELECT * FROM whoop_cycle WHERE id = 12345`.
+- **`assertTrue(found.isPresent)`**: verifica que el ciclo se persisitio y se puede recuperar.
+
+```kotlin
+    @Test
+    fun `filtrar ciclos por rango de fechas`() {
+        val cycle1 = WhoopCycle(id = 1L, userId = 1L, start = Instant.parse("2024-01-10T00:00:00Z"), scoreState = "SCORED")
+        val cycle2 = WhoopCycle(id = 2L, userId = 1L, start = Instant.parse("2024-01-15T00:00:00Z"), scoreState = "SCORED")
+        val cycle3 = WhoopCycle(id = 3L, userId = 1L, start = Instant.parse("2024-01-20T00:00:00Z"), scoreState = "SCORED")
+        cycleRepository.saveAll(listOf(cycle1, cycle2, cycle3))
+
+        val result = cycleRepository.findByStartBetween(
+            Instant.parse("2024-01-12T00:00:00Z"),
+            Instant.parse("2024-01-18T00:00:00Z"),
+            PageRequest.of(0, 10)
+        )
+
+        assertEquals(1, result.totalElements)
+        assertEquals(2L, result.content[0].id)
+    }
+```
+
+**Que verifica**: que el metodo `findByStartBetween` del repositorio genera correctamente la query SQL `WHERE start BETWEEN ? AND ?`. Se guardan 3 ciclos con fechas distintas y se espera que solo 1 caiga dentro del rango.
+
+```kotlin
+    @Test
+    fun `paginacion funciona correctamente`() {
+        for (i in 1L..5L) {
+            cycleRepository.save(
+                WhoopCycle(id = i, userId = 1L, start = Instant.now().minusSeconds(i * 86400), scoreState = "SCORED")
+            )
+        }
+
+        val page1 = cycleRepository.findAll(PageRequest.of(0, 2))
+        assertEquals(2, page1.content.size)
+        assertEquals(5, page1.totalElements)
+        assertTrue(page1.hasNext())
+    }
+```
+
+**Que verifica**: que `PageRequest.of(0, 2)` devuelve solo 2 resultados de los 5 guardados, que `totalElements` es 5 (el total real) y que `hasNext()` es `true` (hay mas paginas).
+
+---
+
+### Test 3: Servicio con Mockito (`CycleServiceTest.kt`)
+
+**Archivo**: `src/test/kotlin/com/example/whoopdavidapi/service/CycleServiceTest.kt`
+
+```kotlin
+package com.example.whoopdavidapi.service
+
+import com.example.whoopdavidapi.mapper.CycleMapper
+import com.example.whoopdavidapi.model.dto.CycleDTO
+import com.example.whoopdavidapi.model.entity.WhoopCycle
+import com.example.whoopdavidapi.repository.CycleRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class CycleServiceTest {
+
+    @Mock
+    lateinit var cycleRepository: CycleRepository
+
+    @Mock
+    lateinit var cycleMapper: CycleMapper
+
+    @InjectMocks
+    lateinit var cycleService: CycleService
+```
+
+**Anatomia**:
+
+- **`@ExtendWith(MockitoExtension::class)`**: NO levanta Spring. Solo activa las anotaciones de Mockito (`@Mock`, `@InjectMocks`). Esto hace el test muy rapido.
+- **`@Mock lateinit var cycleRepository`**: crea un objeto falso que simula el repositorio. Cuando le dices `when(cycleRepository.findAll(...)).thenReturn(...)`, devuelve lo que tu le indiques sin ir a la BD.
+- **`@Mock lateinit var cycleMapper`**: igual para el mapper. No ejecuta MapStruct, devuelve lo que configures.
+- **`@InjectMocks lateinit var cycleService`**: crea una instancia real de `CycleService` e inyecta los mocks anteriores en sus dependencias.
+
+```kotlin
+    @Test
+    fun `getCycles sin filtros devuelve todos los ciclos paginados`() {
+        val entity = WhoopCycle(
+            id = 1L, userId = 100L,
+            start = Instant.parse("2024-01-15T08:00:00Z"),
+            scoreState = "SCORED", strain = 15.5f
+        )
+        val dto = CycleDTO(
+            id = 1L, userId = 100L,
+            createdAt = null, updatedAt = null,
+            start = Instant.parse("2024-01-15T08:00:00Z"),
+            end = null, timezoneOffset = null,
+            scoreState = "SCORED", strain = 15.5f,
+            kilojoule = null, averageHeartRate = null, maxHeartRate = null
+        )
+
+        val pageable = PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "start"))
+        val page = PageImpl(listOf(entity), pageable, 1)
+
+        `when`(cycleRepository.findAll(pageable)).thenReturn(page)
+        `when`(cycleMapper.toDto(entity)).thenReturn(dto)
+
+        val result = cycleService.getCycles(null, null, 1, 100)
+
+        assertEquals(1, result.data.size)
+        assertEquals(1L, result.data[0].id)
+        assertEquals(15.5f, result.data[0].strain)
+        assertEquals(1, result.pagination.page)
+        assertEquals(false, result.pagination.hasMore)
+    }
+```
+
+**Flujo del test**:
+
+1. **Preparar datos**: crea una entidad `WhoopCycle` y un DTO `CycleDTO`.
+2. **Configurar mocks**: cuando el servicio llame a `cycleRepository.findAll(pageable)`, devuelve la pagina con la entidad. Cuando llame a `cycleMapper.toDto(entity)`, devuelve el DTO.
+3. **Ejecutar**: llama a `cycleService.getCycles(null, null, 1, 100)` -- esto invoca la logica real del servicio, que usa los mocks.
+4. **Verificar**: comprueba que el resultado tiene los valores esperados.
+
+**Que estamos testeando realmente**: la logica del servicio -- como construye el `Pageable`, como decide que metodo del repositorio llamar (con filtros o sin ellos), como transforma entidades a DTOs, como construye el `PaginatedResponse`.
+
+```kotlin
+    @Test
+    fun `getCycles con filtro from usa findByStartGreaterThanEqual`() {
+        val from = Instant.parse("2024-01-10T00:00:00Z")
+        val pageable = PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "start"))
+        val emptyPage = PageImpl(emptyList<WhoopCycle>(), pageable, 0)
+
+        `when`(cycleRepository.findByStartGreaterThanEqual(from, pageable)).thenReturn(emptyPage)
+
+        val result = cycleService.getCycles(from, null, 1, 100)
+
+        assertEquals(0, result.data.size)
+        assertEquals(0, result.pagination.totalCount)
+    }
+```
+
+**Que verifica**: que cuando se pasa un parametro `from`, el servicio llama a `findByStartGreaterThanEqual` en vez de `findAll`. Si el servicio llamara al metodo incorrecto, Mockito no tendria configurada la respuesta y el test fallaria.
+
+---
+
+### Test 4: Controller con MockMvc (`CycleControllerTest.kt`)
+
+**Archivo**: `src/test/kotlin/com/example/whoopdavidapi/controller/CycleControllerTest.kt`
+
+```kotlin
+package com.example.whoopdavidapi.controller
+
+import com.example.whoopdavidapi.model.dto.CycleDTO
+import com.example.whoopdavidapi.model.dto.PaginatedResponse
+import com.example.whoopdavidapi.model.dto.PaginationInfo
+import com.example.whoopdavidapi.service.CycleService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.time.Instant
+```
+
+Fijate en los imports -- aqui estan los cambios de Spring Boot 4:
+
+- **`org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc`**: antes era `org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc`
+- **`org.springframework.test.context.bean.override.mockito.MockitoBean`**: antes era `org.springframework.boot.test.mock.mockito.MockBean`
+
+```kotlin
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class CycleControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var cycleService: CycleService
+```
+
+- **`@SpringBootTest`**: levanta todo el contexto (incluida la seguridad).
+- **`@AutoConfigureMockMvc`**: crea un `MockMvc` auto-configurado que Spring inyecta.
+- **`@MockitoBean lateinit var cycleService`**: reemplaza el `CycleService` real en el contexto de Spring por un mock. Asi el controller llama al mock en vez de al servicio real.
+
+```kotlin
+    @Test
+    fun `GET cycles sin autenticacion devuelve 401`() {
+        mockMvc.perform(get("/api/v1/cycles"))
+            .andExpect(status().isUnauthorized)
+    }
+```
+
+**Que verifica**: que Spring Security esta configurado correctamente y rechaza peticiones a `/api/v1/cycles` sin credenciales. Devuelve HTTP 401 Unauthorized.
+
+```kotlin
+    @Test
+    fun `GET cycles con Basic Auth devuelve 200`() {
+        val response = PaginatedResponse(
+            data = listOf(
+                CycleDTO(
+                    id = 1L, userId = 100L,
+                    createdAt = null, updatedAt = null,
+                    start = Instant.parse("2024-01-15T08:00:00Z"),
+                    end = Instant.parse("2024-01-16T08:00:00Z"),
+                    timezoneOffset = null,
+                    scoreState = "SCORED", strain = 15.5f,
+                    kilojoule = 2500.0f, averageHeartRate = 72, maxHeartRate = 185
+                )
+            ),
+            pagination = PaginationInfo(page = 1, pageSize = 100, totalCount = 1, hasMore = false)
+        )
+
+        `when`(cycleService.getCycles(null, null, 1, 100)).thenReturn(response)
+
+        mockMvc.perform(
+            get("/api/v1/cycles")
+                .with(httpBasic("powerbi", "changeme"))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].strain").value(15.5))
+            .andExpect(jsonPath("$.pagination.totalCount").value(1))
+            .andExpect(jsonPath("$.pagination.hasMore").value(false))
+    }
+```
+
+**Que verifica**:
+1. Que con Basic Auth (`powerbi`/`changeme`) se obtiene HTTP 200.
+2. Que la respuesta JSON tiene la estructura correcta (`$.data` es un array, `$.pagination` tiene los campos esperados).
+3. Que Jackson serializa correctamente los DTOs a JSON.
+
+```kotlin
+    @Test
+    fun `GET cycles con parametros de paginacion`() {
+        val response = PaginatedResponse(
+            data = emptyList<CycleDTO>(),
+            pagination = PaginationInfo(page = 2, pageSize = 50, totalCount = 0, hasMore = false)
+        )
+
+        `when`(cycleService.getCycles(null, null, 2, 50)).thenReturn(response)
+
+        mockMvc.perform(
+            get("/api/v1/cycles")
+                .param("page", "2")
+                .param("pageSize", "50")
+                .with(httpBasic("powerbi", "changeme"))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.pagination.page").value(2))
+            .andExpect(jsonPath("$.pagination.pageSize").value(50))
+    }
+```
+
+**Que verifica**: que los parametros de query `?page=2&pageSize=50` se pasan correctamente al servicio. Verifica que el binding de `@RequestParam` funciona.
+
+---
+
+## 7. Gotchas de Spring Boot 4
+
+Spring Boot 4.0.2 introdujo cambios importantes en los paquetes de las anotaciones de test. Si vienes de Spring Boot 3.x, estas son las migraciones:
+
+### Los paquetes de anotaciones de test cambiaron
+
+| Anotacion | Spring Boot 3.x | Spring Boot 4.x |
+|-----------|-----------------|-----------------|
+| `@DataJpaTest` | `org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest` | `org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest` |
+| `@WebMvcTest` | `org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest` | `org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest` |
+| `@AutoConfigureMockMvc` | `org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc` | `org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc` |
+| `@MockBean` | `org.springframework.boot.test.mock.mockito.MockBean` | **Eliminada** -- usar `@MockitoBean` |
+| `@MockitoBean` | No existia | `org.springframework.test.context.bean.override.mockito.MockitoBean` |
+
+### `@MockBean` ya no existe -- usar `@MockitoBean`
+
+En Spring Boot 3.x se usaba `@MockBean` del paquete `org.springframework.boot.test.mock.mockito`. En Spring Boot 4.x esta anotacion fue reemplazada por `@MockitoBean` del paquete `org.springframework.test.context.bean.override.mockito`.
+
+Antes (Spring Boot 3):
+```kotlin
+import org.springframework.boot.test.mock.mockito.MockBean
+
+@MockBean
+lateinit var cycleService: CycleService
+```
+
+Ahora (Spring Boot 4):
+```kotlin
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@MockitoBean
+lateinit var cycleService: CycleService
+```
+
+### kapt debe desactivarse para las fuentes de test
+
+Si usas `kapt` (por ejemplo para MapStruct), las tareas de kapt para test (`kaptTestKotlin`, `kaptGenerateStubsTestKotlin`) pueden fallar porque intentan procesar las nuevas anotaciones de test de Spring Boot 4 y no las reconocen.
+
+La solucion esta en `build.gradle.kts`:
+
+```kotlin
+// Desactivar kapt para test sources (no hay annotation processors en tests)
+tasks.matching { it.name == "kaptTestKotlin" || it.name == "kaptGenerateStubsTestKotlin" }.configureEach {
+    enabled = false
+}
+```
+
+Esto es seguro porque en nuestro proyecto no tenemos annotation processors que necesiten ejecutarse sobre el codigo de test (MapStruct solo procesa los mappers en `src/main`).
+
+### Starters de test tambien cambiaron
+
+En `build.gradle.kts`, las dependencias de test usan los nuevos starters de Spring Boot 4:
+
+```kotlin
+testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")
+testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+testImplementation("org.springframework.boot:spring-boot-starter-security-test")
+testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+```
+
+Estos reemplazan a los starters generico `spring-boot-starter-test` de Spring Boot 3.x, proporcionando las dependencias de test organizadas por modulo.
+
+---
+
+## 8. Configuracion en build.gradle.kts
+
+**Archivo**: `build.gradle.kts`
+
+Las partes relevantes para testing:
+
+```kotlin
+dependencies {
+    // Test
+    testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-security-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+```
+
+- **`spring-boot-starter-*-test`**: incluye JUnit 5, Mockito, AssertJ, MockMvc, H2 y otras herramientas de test.
+- **`spring-boot-starter-security-test`**: proporciona `SecurityMockMvcRequestPostProcessors.httpBasic()` para simular autenticacion en tests.
+- **`kotlin-test-junit5`**: integracion de Kotlin con JUnit 5.
+- **`junit-platform-launcher`**: necesario en runtime para que Gradle ejecute los tests con JUnit 5.
+
+```kotlin
+// Desactivar kapt para test sources
+tasks.matching { it.name == "kaptTestKotlin" || it.name == "kaptGenerateStubsTestKotlin" }.configureEach {
+    enabled = false
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()  // Usa JUnit 5 como motor de tests
+}
+```
+
+---
+
+## 9. Documentacion oficial
+
+- [Spring Boot Testing - Referencia oficial](https://docs.spring.io/spring-boot/reference/testing/index.html)
+- [JUnit 5 User Guide](https://junit.org/junit5/docs/current/user-guide/)
+- [Mockito Framework](https://site.mockito.org/)
+- [Spring Security Testing](https://docs.spring.io/spring-security/reference/servlet/test/index.html)
+- [MockMvc - Documentacion de Spring](https://docs.spring.io/spring-framework/reference/testing/spring-mvc-test-framework.html)
+- [Spring Boot 4 Release Notes - Test annotations migration](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes)

--- a/docs/13-docker-k8s.md
+++ b/docs/13-docker-k8s.md
@@ -1,0 +1,871 @@
+# 13. Docker y Kubernetes
+
+## Indice
+
+1. [Que es Docker](#1-que-es-docker)
+2. [Dockerfile explicado linea por linea](#2-dockerfile-explicado-linea-por-linea)
+3. [Que es Kubernetes](#3-que-es-kubernetes)
+4. [Estructura de manifiestos K8s del proyecto](#4-estructura-de-manifiestos-k8s-del-proyecto)
+5. [Conceptos K8s explicados con nuestro codigo](#5-conceptos-k8s-explicados-con-nuestro-codigo)
+6. [Flujo completo: del codigo al pod](#6-flujo-completo-del-codigo-al-pod)
+7. [Documentacion oficial](#7-documentacion-oficial)
+
+---
+
+## 1. Que es Docker
+
+Docker es una herramienta que empaqueta tu aplicacion junto con todo lo que necesita para ejecutarse (JRE, dependencias, configuracion) en una **imagen**. Esa imagen se puede ejecutar en cualquier maquina que tenga Docker instalado, garantizando que funciona igual en desarrollo, CI/CD y produccion.
+
+### Conceptos clave
+
+| Concepto | Descripcion |
+|----------|-------------|
+| **Imagen** | Un paquete inmutable con tu app + dependencias. Se crea a partir de un `Dockerfile`. |
+| **Contenedor** | Una instancia en ejecucion de una imagen. Es como un proceso aislado. |
+| **Dockerfile** | Un archivo de instrucciones para construir una imagen. |
+| **Multi-stage build** | Tecnica que usa multiples `FROM` para separar la fase de compilacion de la de ejecucion, reduciendo el tamano de la imagen final. |
+| **Layer caching** | Docker cachea cada instruccion (`RUN`, `COPY`, etc.) como una capa. Si una capa no cambia, no se re-ejecuta. |
+| **Fat JAR (bootJar)** | Spring Boot empaqueta toda la aplicacion + dependencias en un unico archivo `.jar` ejecutable. |
+
+---
+
+## 2. Dockerfile explicado linea por linea
+
+**Archivo**: `Dockerfile`
+
+```dockerfile
+# Stage 1: Build
+FROM eclipse-temurin:24-jdk-noble AS builder
+WORKDIR /app
+COPY build.gradle.kts settings.gradle.kts gradlew ./
+COPY gradle ./gradle
+RUN ./gradlew dependencies --no-daemon || true
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon -x test
+
+# Stage 2: Runtime
+FROM eclipse-temurin:24-jre-alpine
+RUN addgroup -S spring && adduser -S spring -G spring
+RUN apk add --no-cache curl
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+RUN chown spring:spring app.jar
+USER spring:spring
+EXPOSE 8080
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+```
+
+### Stage 1: Build (compilacion)
+
+```dockerfile
+FROM eclipse-temurin:24-jdk-noble AS builder
+```
+- Usa la imagen base **Eclipse Temurin JDK 24** sobre Ubuntu Noble (24.04).
+- `JDK` (no JRE) porque necesitamos el compilador Java para construir el proyecto.
+- `AS builder` le da un nombre a esta etapa para poder referenciarla despues.
+
+```dockerfile
+WORKDIR /app
+```
+- Establece `/app` como directorio de trabajo dentro del contenedor. Todos los comandos posteriores se ejecutan desde aqui.
+
+```dockerfile
+COPY build.gradle.kts settings.gradle.kts gradlew ./
+COPY gradle ./gradle
+RUN ./gradlew dependencies --no-daemon || true
+```
+- **Truco de cache de capas**: primero se copian SOLO los archivos de configuracion de Gradle y se descargan las dependencias.
+- Como las dependencias cambian poco, Docker cachea esta capa. Si solo cambias codigo fuente (no `build.gradle.kts`), esta capa se reutiliza y no se vuelven a descargar las dependencias.
+- `--no-daemon` evita que el daemon de Gradle quede corriendo en el contenedor (no tiene sentido en builds de CI/Docker).
+- `|| true` evita que el build falle si hay dependencias que no se resuelven en esta fase (algunas necesitan el codigo fuente).
+
+```dockerfile
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon -x test
+```
+- Ahora si se copia el codigo fuente.
+- `bootJar` es la tarea de Spring Boot que genera el fat JAR (un unico `.jar` con toda la aplicacion + dependencias embebidas).
+- `-x test` salta los tests (ya se ejecutaron en el workflow de CI).
+
+### Stage 2: Runtime (ejecucion)
+
+```dockerfile
+FROM eclipse-temurin:24-jre-alpine
+```
+- **Segunda imagen base**: esta vez solo **JRE** (Java Runtime Environment), no JDK.
+- Usa **Alpine Linux**, que es mucho mas pequena que Ubuntu (~5 MB vs ~80 MB).
+- **Resultado**: la imagen final NO contiene el compilador Java, ni el codigo fuente, ni Gradle, ni las dependencias de compilacion. Solo el JAR y el JRE.
+
+```dockerfile
+RUN addgroup -S spring && adduser -S spring -G spring
+```
+- Crea un usuario `spring` sin privilegios de root. **Seguridad**: si alguien compromete la aplicacion, no tiene acceso root al contenedor.
+- `-S` = system user/group (sin home directory, sin password).
+
+```dockerfile
+RUN apk add --no-cache curl
+```
+- Instala `curl` para el `HEALTHCHECK`. Alpine no lo incluye por defecto.
+- `--no-cache` evita almacenar el indice de paquetes, reduciendo el tamano de la imagen.
+
+```dockerfile
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+```
+- **`--from=builder`**: copia el JAR desde la etapa 1 (builder) a la etapa 2 (runtime).
+- Solo se copia el artefacto final. Todo el tooling de compilacion queda descartado.
+
+```dockerfile
+RUN chown spring:spring app.jar
+USER spring:spring
+```
+- Cambia el propietario del JAR al usuario `spring`.
+- **`USER spring:spring`**: a partir de aqui, todos los comandos se ejecutan como el usuario `spring`, no como root.
+
+```dockerfile
+EXPOSE 8080
+```
+- Documenta que el contenedor escucha en el puerto 8080. Es informativo, no abre el puerto realmente (eso lo hace Kubernetes con el `containerPort` o Docker con `-p`).
+
+```dockerfile
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
+```
+- Define opciones de JVM por defecto: 256 MB de heap minimo, 512 MB maximo.
+- Se puede sobrescribir desde Kubernetes con una variable de entorno `JAVA_OPTS`.
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+```
+- Docker comprueba la salud del contenedor cada 30 segundos.
+- `--start-period=60s`: da 60 segundos al arranque de Spring Boot antes de empezar a comprobar.
+- `--retries=3`: despues de 3 fallos consecutivos, marca el contenedor como `unhealthy`.
+- El endpoint `/actuator/health` es de Spring Boot Actuator.
+
+```dockerfile
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+```
+- Arranca la aplicacion. Usa `sh -c` para que la variable `$JAVA_OPTS` se interprete.
+- Si usara `["java", "$JAVA_OPTS", "-jar", "app.jar"]` (exec form directa), `$JAVA_OPTS` no se expandiria.
+
+### Comparacion de tamano (multi-stage vs single-stage)
+
+| Tipo de imagen | Contiene | Tamano aprox. |
+|----------------|----------|---------------|
+| JDK completo (single-stage) | JDK 24 + Gradle + sources + JAR | ~800 MB |
+| JRE Alpine (multi-stage) | JRE 24 + JAR + curl | ~200 MB |
+
+---
+
+## 3. Que es Kubernetes
+
+Kubernetes (K8s) es un **orquestador de contenedores**. Se encarga de:
+
+- **Desplegar** contenedores en un cluster de servidores.
+- **Escalar** (mas replicas si hay mas carga).
+- **Recuperar** (si un contenedor muere, Kubernetes lo reinicia).
+- **Balancear** trafico entre replicas.
+- **Gestionar** secretos, configuracion, almacenamiento y certificados TLS.
+
+Nuestro cluster usa **RKE2** (distribucion de Kubernetes de Rancher) en el servidor `138.199.157.58` con estos componentes adicionales:
+
+| Componente | Funcion |
+|------------|---------|
+| **Traefik** | Ingress controller / reverse proxy. Enruta trafico externo a los pods. |
+| **Longhorn** | Almacenamiento persistente distribuido. Proporciona PersistentVolumes. |
+| **cert-manager** | Genera y renueva certificados TLS automaticamente (via Cloudflare DNS). |
+| **Keel** | Detecta nuevas imagenes Docker y actualiza los deployments automaticamente. |
+
+---
+
+## 4. Estructura de manifiestos K8s del proyecto
+
+```
+k8s/
+├── 00-namespace.yaml                    # Namespace compartido para PostgreSQL
+├── 01-postgresql/
+│   ├── configmap-init.yaml              # Script SQL de inicializacion
+│   ├── pvc.yaml                         # PersistentVolumeClaim (2 Gi con Longhorn)
+│   ├── secret.yaml                      # Credenciales de PostgreSQL
+│   ├── service.yaml                     # Service ClusterIP (acceso interno)
+│   ├── service-external.yaml            # Service NodePort (acceso externo: 30434)
+│   └── statefulset.yaml                 # StatefulSet de PostgreSQL 16
+├── 02-api-dev/
+│   ├── 00-namespace.yaml                # Namespace: apptolast-whoop-david-api-dev
+│   ├── 01-secret.yaml                   # Secrets de la API (Whoop, PowerBI, DB, encryption)
+│   ├── 02-configmap.yaml                # ConfigMap con application.yaml override
+│   ├── 03-deployment.yaml               # Deployment con anotaciones Keel
+│   ├── 04-service.yaml                  # Service ClusterIP
+│   ├── 05-certificate.yaml              # Certificate cert-manager (TLS)
+│   └── 06-ingressroute.yaml             # IngressRoute Traefik + Middleware seguridad
+└── 03-api-prod/
+    ├── 00-namespace.yaml                # Namespace: apptolast-whoop-david-api-prod
+    ├── 01-secret.yaml                   # Secrets de produccion
+    ├── 02-configmap.yaml                # ConfigMap con application.yaml override
+    ├── 03-deployment.yaml               # Deployment (image: latest, profile: prod)
+    ├── 04-service.yaml                  # Service ClusterIP
+    ├── 05-certificate.yaml              # Certificate (david-whoop.apptolast.com)
+    └── 06-ingressroute.yaml             # IngressRoute Traefik
+```
+
+**Tres entornos separados por namespaces**:
+- `apptolast-whoop-david-api` -- contiene solo PostgreSQL (compartido)
+- `apptolast-whoop-david-api-dev` -- API en modo demo (imagen `:develop`)
+- `apptolast-whoop-david-api-prod` -- API en modo produccion (imagen `:latest`)
+
+---
+
+## 5. Conceptos K8s explicados con nuestro codigo
+
+### 5.1 Namespace: aislamiento logico
+
+**Archivo**: `k8s/00-namespace.yaml`
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apptolast-whoop-david-api
+  labels:
+    name: apptolast-whoop-david-api
+    app: whoop-david-api
+```
+
+**Que es**: un Namespace es como una carpeta en Kubernetes. Aisla recursos para que no se mezclen. Los pods, servicios y secretos de un namespace no son visibles desde otro (a menos que se use el nombre DNS completo).
+
+**Por que 3 namespaces**: separar PostgreSQL, dev y prod permite:
+- Limitar permisos por namespace (RBAC).
+- Evitar que un error en dev afecte a prod.
+- Tener secretos diferentes por entorno.
+
+### 5.2 StatefulSet vs Deployment: bases de datos
+
+**Archivo**: `k8s/01-postgresql/statefulset.yaml`
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql
+  namespace: apptolast-whoop-david-api
+spec:
+  serviceName: postgresql
+  replicas: 1
+  template:
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+      - name: postgresql
+        image: postgres:16-alpine
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-credentials
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-credentials
+              key: POSTGRES_PASSWORD
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-credentials
+              key: POSTGRES_DB
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        - name: init-scripts
+          mountPath: /docker-entrypoint-initdb.d
+        livenessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB && psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"]
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: postgresql-data
+      - name: init-scripts
+        configMap:
+          name: postgresql-init-scripts
+```
+
+**Por que StatefulSet y no Deployment**:
+
+| Caracteristica | Deployment | StatefulSet |
+|---------------|------------|-------------|
+| Identidad del pod | Aleatoria (pod-xyz123) | Estable (postgresql-0) |
+| Almacenamiento | Efimero (se pierde al reiniciar) | Persistente (PVC se mantiene) |
+| Orden de arranque | Todos a la vez | Uno a uno, en orden |
+| Caso de uso | Apps stateless (API) | Apps stateful (BD, caches) |
+
+PostgreSQL necesita que los datos sobrevivan a los reinicios, por eso usa StatefulSet + PersistentVolumeClaim.
+
+**Las credenciales vienen de un Secret** (`secretKeyRef`), no estan hardcodeadas en el manifiesto.
+
+**`securityContext.fsGroup: 999`**: el grupo 999 es el grupo `postgres` dentro del contenedor. Esto asegura que los archivos del volumen persistente tengan los permisos correctos.
+
+### 5.3 PersistentVolumeClaim: almacenamiento con Longhorn
+
+**Archivo**: `k8s/01-postgresql/pvc.yaml`
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-data
+  namespace: apptolast-whoop-david-api
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+- **`storageClassName: longhorn`**: usa Longhorn como proveedor de almacenamiento. Longhorn replica los datos en multiples nodos del cluster para durabilidad.
+- **`ReadWriteOnce`**: solo un pod puede montar este volumen a la vez (correcto para una BD con 1 replica).
+- **`2Gi`**: solicita 2 GB de almacenamiento.
+
+### 5.4 Secret: datos sensibles
+
+**Archivo**: `k8s/01-postgresql/secret.yaml`
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-credentials
+  namespace: apptolast-whoop-david-api
+type: Opaque
+stringData:
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: "..."
+  POSTGRES_DB: whoop_david
+```
+
+- **`type: Opaque`**: es el tipo generico para secretos arbitrarios.
+- **`stringData`**: permite escribir los valores en texto plano en el YAML. Kubernetes los codifica automaticamente en base64 al almacenarlos en etcd.
+- Los pods referencian estos secretos con `secretKeyRef` en sus variables de entorno.
+
+**Importante**: en produccion, estos secretos deberian gestionarse con herramientas como Sealed Secrets, Vault o SOPS. Tenerlos en texto plano en Git es un riesgo de seguridad (aceptable para aprendizaje).
+
+### 5.5 ConfigMap: configuracion no sensible
+
+**Archivo**: `k8s/02-api-dev/02-configmap.yaml`
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whoop-david-api-config
+  namespace: apptolast-whoop-david-api-dev
+data:
+  application.yaml: |
+    spring:
+      datasource:
+        url: jdbc:postgresql://postgresql.apptolast-whoop-david-api.svc.cluster.local:5432/whoop_david_dev
+        username: ${DB_USERNAME}
+        password: ${DB_PASSWORD}
+        driver-class-name: org.postgresql.Driver
+      h2:
+        console:
+          enabled: false
+      jpa:
+        hibernate:
+          ddl-auto: update
+        properties:
+          hibernate:
+            dialect: org.hibernate.dialect.PostgreSQLDialect
+```
+
+- Contiene el `application.yaml` que se inyecta en el pod como un archivo montado en `/app/config/`.
+- **`SPRING_CONFIG_ADDITIONAL_LOCATION=file:/app/config/`** en el Deployment le dice a Spring Boot que lea esta configuracion adicional.
+- La URL de la BD usa el DNS interno de Kubernetes: `postgresql.apptolast-whoop-david-api.svc.cluster.local` -- esto es `<servicio>.<namespace>.svc.cluster.local`.
+- `${DB_USERNAME}` y `${DB_PASSWORD}` se resuelven desde las variables de entorno del pod (que vienen del Secret).
+
+**Diferencia Secret vs ConfigMap**:
+- **Secret**: datos sensibles (passwords, tokens, claves). Se almacenan cifrados en etcd.
+- **ConfigMap**: datos no sensibles (configuracion, URLs, flags). Se almacenan en texto plano.
+
+### 5.6 Deployment: la API
+
+**Archivo**: `k8s/02-api-dev/03-deployment.yaml`
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoop-david-api
+  namespace: apptolast-whoop-david-api-dev
+  labels:
+    app: whoop-david-api
+    environment: development
+  annotations:
+    keel.sh/policy: force
+    keel.sh/pollSchedule: "@every 1m"
+    keel.sh/trigger: poll
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: whoop-david-api
+      environment: development
+  template:
+    metadata:
+      labels:
+        app: whoop-david-api
+        environment: development
+    spec:
+      containers:
+        - name: whoop-david-api
+          image: apptolast/whoop-david-api:develop
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "demo"
+            - name: SPRING_CONFIG_ADDITIONAL_LOCATION
+              value: "file:/app/config/"
+            - name: JAVA_OPTS
+              value: "-Xms256m -Xmx512m"
+            - name: WHOOP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: whoop-david-api-secrets
+                  key: WHOOP_CLIENT_ID
+            - name: WHOOP_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: whoop-david-api-secrets
+                  key: WHOOP_CLIENT_SECRET
+            - name: POWERBI_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: whoop-david-api-secrets
+                  key: POWERBI_USERNAME
+            - name: POWERBI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: whoop-david-api-secrets
+                  key: POWERBI_PASSWORD
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: whoop-david-api-secrets
+                  key: DB_USERNAME
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: whoop-david-api-secrets
+                  key: DB_PASSWORD
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: whoop-david-api-secrets
+                  key: ENCRYPTION_KEY
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 384Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 90
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            failureThreshold: 30
+      volumes:
+        - name: config
+          configMap:
+            name: whoop-david-api-config
+            items:
+              - key: application.yaml
+                path: application.yaml
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+```
+
+Explicacion por secciones:
+
+#### Anotaciones Keel (auto-deploy)
+
+```yaml
+annotations:
+  keel.sh/policy: force
+  keel.sh/pollSchedule: "@every 1m"
+  keel.sh/trigger: poll
+```
+
+- **Keel** es un operador de Kubernetes que vigila Docker Hub.
+- `keel.sh/policy: force` -- actualiza el deployment cada vez que hay una nueva imagen, sin importar el tag.
+- `keel.sh/pollSchedule: "@every 1m"` -- comprueba cada minuto si hay una imagen nueva.
+- `keel.sh/trigger: poll` -- usa polling (en vez de webhooks).
+- **Resultado**: cuando el workflow de CD sube una nueva imagen `apptolast/whoop-david-api:develop`, Keel la detecta en ~1 minuto y actualiza el deployment automaticamente.
+
+#### Estrategia de rolling update
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+```
+
+- `maxSurge: 1` -- puede crear hasta 1 pod nuevo antes de eliminar el viejo.
+- `maxUnavailable: 0` -- nunca elimina el pod viejo hasta que el nuevo este listo.
+- **Resultado**: zero-downtime deployment. Siempre hay al menos 1 pod sirviendo trafico.
+
+#### Imagen y perfil
+
+```yaml
+image: apptolast/whoop-david-api:develop    # Dev usa tag :develop
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "demo"                           # Perfil Spring Boot activo
+```
+
+Comparacion dev vs prod:
+
+| | Dev | Prod |
+|---|-----|------|
+| Imagen | `apptolast/whoop-david-api:develop` | `apptolast/whoop-david-api:latest` |
+| Perfil | `demo` | `prod` |
+| CPU limit | 500m | 1000m |
+| Dominio | `david-whoop-dev.apptolast.com` | `david-whoop.apptolast.com` |
+
+#### Resources (limites de recursos)
+
+```yaml
+resources:
+  requests:
+    cpu: 200m       # Garantiza 200 milicores (0.2 CPU)
+    memory: 384Mi   # Garantiza 384 MB RAM
+  limits:
+    cpu: 500m       # Maximo 500 milicores (0.5 CPU)
+    memory: 768Mi   # Maximo 768 MB RAM
+```
+
+- **requests**: lo que Kubernetes garantiza al pod. Se usa para decidir en que nodo colocar el pod.
+- **limits**: el tope maximo. Si el pod supera el limite de memoria, Kubernetes lo mata (OOMKilled). Si supera CPU, lo throttlea.
+
+#### Probes (sondas de salud)
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /actuator/health
+    port: 8080
+  initialDelaySeconds: 90
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 5
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /actuator/health
+    port: 8080
+  initialDelaySeconds: 0
+  periodSeconds: 5
+  failureThreshold: 30
+```
+
+| Probe | Pregunta que responde | Si falla... |
+|-------|----------------------|-------------|
+| **startupProbe** | "Ya termino de arrancar?" | Espera mas (hasta 30 * 5s = 150s) |
+| **readinessProbe** | "Puede recibir trafico?" | Deja de enviarle trafico (pero no lo mata) |
+| **livenessProbe** | "Sigue vivo?" | Kubernetes lo reinicia |
+
+**Por que 3 probes**: Spring Boot tarda bastante en arrancar (~60-90s). Sin `startupProbe`, la `livenessProbe` podria matar el pod antes de que termine de arrancar.
+
+#### Volume mount del ConfigMap
+
+```yaml
+volumeMounts:
+  - name: config
+    mountPath: /app/config
+    readOnly: true
+volumes:
+  - name: config
+    configMap:
+      name: whoop-david-api-config
+      items:
+        - key: application.yaml
+          path: application.yaml
+```
+
+- Monta el contenido del ConfigMap `whoop-david-api-config` como un archivo en `/app/config/application.yaml`.
+- La variable `SPRING_CONFIG_ADDITIONAL_LOCATION=file:/app/config/` le dice a Spring Boot que lea este archivo ademas del `application.yaml` embebido en el JAR.
+
+### 5.7 Service: exponer la aplicacion
+
+**Archivo**: `k8s/02-api-dev/04-service.yaml`
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoop-david-api
+  namespace: apptolast-whoop-david-api-dev
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: whoop-david-api
+    environment: development
+```
+
+**Que es un Service**: un Service da una IP estable y un nombre DNS a un conjunto de pods. Los pods pueden morir y renacer con IPs distintas; el Service siempre los encuentra via `selector`.
+
+**Tipos de Service en nuestro proyecto**:
+
+| Tipo | Acceso | Ejemplo |
+|------|--------|---------|
+| **ClusterIP** | Solo dentro del cluster | `whoop-david-api` (API) y `postgresql` (BD interna) |
+| **NodePort** | Desde fuera del cluster via IP:puerto | `postgresql-external` (puerto 30434 para DBeaver/pgAdmin) |
+
+**ClusterIP para la API**: el acceso externo lo gestiona Traefik (IngressRoute), no el Service directamente.
+
+**NodePort para PostgreSQL externo** (`k8s/01-postgresql/service-external.yaml`):
+
+```yaml
+spec:
+  type: NodePort
+  ports:
+  - port: 5432
+    targetPort: 5432
+    nodePort: 30434
+```
+
+Permite conectarse a PostgreSQL desde herramientas externas como DBeaver usando `138.199.157.58:30434`.
+
+### 5.8 Certificate: TLS automatico con cert-manager
+
+**Archivo**: `k8s/02-api-dev/05-certificate.yaml`
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: whoop-david-api-tls
+  namespace: apptolast-whoop-david-api-dev
+spec:
+  secretName: whoop-david-api-tls
+  issuerRef:
+    name: cloudflare-clusterissuer
+    kind: ClusterIssuer
+  dnsNames:
+    - david-whoop-dev.apptolast.com
+  duration: 2160h      # 90 dias
+  renewBefore: 720h    # Renueva 30 dias antes de expirar
+```
+
+- **cert-manager** es un operador de Kubernetes que gestiona certificados TLS automaticamente.
+- **`cloudflare-clusterissuer`**: usa el DNS challenge de Cloudflare para validar el dominio y obtener un certificado de Let's Encrypt.
+- El certificado se almacena como un Secret de Kubernetes llamado `whoop-david-api-tls`.
+- Se renueva automaticamente 30 dias antes de expirar.
+
+**Dominios**:
+- Dev: `david-whoop-dev.apptolast.com`
+- Prod: `david-whoop.apptolast.com`
+
+### 5.9 IngressRoute: Traefik como reverse proxy
+
+**Archivo**: `k8s/02-api-dev/06-ingressroute.yaml`
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: whoop-david-api
+  namespace: apptolast-whoop-david-api-dev
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`david-whoop-dev.apptolast.com`)
+      kind: Rule
+      services:
+        - name: whoop-david-api
+          port: 8080
+      middlewares:
+        - name: security-headers
+  tls:
+    secretName: whoop-david-api-tls
+```
+
+- **IngressRoute** es un CRD (Custom Resource Definition) de Traefik. Funciona como un Ingress pero con mas funcionalidad.
+- **`entryPoints: websecure`**: solo acepta HTTPS (puerto 443).
+- **`match: Host(...)`**: enruta peticiones para `david-whoop-dev.apptolast.com` al servicio `whoop-david-api:8080`.
+- **`tls.secretName`**: usa el certificado generado por cert-manager.
+
+#### Middleware de seguridad
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: security-headers
+  namespace: apptolast-whoop-david-api-dev
+spec:
+  headers:
+    customResponseHeaders:
+      X-Robots-Tag: "noindex, nofollow"
+      Server: ""
+    sslRedirect: true
+    browserXssFilter: true
+    contentTypeNosniff: true
+    forceSTSHeader: true
+    stsIncludeSubdomains: true
+    stsPreload: true
+    stsSeconds: 31536000
+    frameDeny: true
+```
+
+| Header | Proteccion |
+|--------|-----------|
+| `X-Robots-Tag: noindex, nofollow` | Evita que buscadores indexen la API |
+| `Server: ""` | Oculta la version del servidor |
+| `sslRedirect: true` | Redirige HTTP a HTTPS |
+| `browserXssFilter: true` | Activa el filtro XSS del navegador |
+| `contentTypeNosniff: true` | Previene MIME-type sniffing |
+| `forceSTSHeader + stsSeconds` | HSTS: fuerza HTTPS durante 1 ano |
+| `frameDeny: true` | Previene clickjacking (no permitir iframes) |
+
+### 5.10 ConfigMap de inicializacion de PostgreSQL
+
+**Archivo**: `k8s/01-postgresql/configmap-init.yaml`
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-init-scripts
+  namespace: apptolast-whoop-david-api
+data:
+  01-create-databases.sql: |
+    -- Create dev database (prod database 'whoop_david' is created automatically as POSTGRES_DB)
+    CREATE DATABASE whoop_david_dev;
+    GRANT ALL PRIVILEGES ON DATABASE whoop_david_dev TO admin;
+```
+
+- Se monta en `/docker-entrypoint-initdb.d/` del contenedor de PostgreSQL.
+- PostgreSQL ejecuta automaticamente los scripts SQL de este directorio al inicializarse por primera vez.
+- Crea la base de datos de dev (`whoop_david_dev`). La de prod (`whoop_david`) ya la crea PostgreSQL automaticamente porque esta configurada como `POSTGRES_DB`.
+
+---
+
+## 6. Flujo completo: del codigo al pod
+
+```
+1. Developer hace push a la rama dev
+        |
+2. GitHub Actions CI: ./gradlew build (compila + tests)
+        |
+3. GitHub Actions CD: ./gradlew bootJar + docker build + docker push
+        |
+4. Imagen subida a Docker Hub: apptolast/whoop-david-api:develop
+        |
+5. Keel detecta nueva imagen (poll cada 1 min)
+        |
+6. Keel actualiza el Deployment (cambia el digest de la imagen)
+        |
+7. Kubernetes crea un nuevo pod con la nueva imagen
+        |
+8. startupProbe verifica que Spring Boot arranco
+        |
+9. readinessProbe confirma que puede recibir trafico
+        |
+10. Kubernetes redirige el Service al nuevo pod
+        |
+11. Kubernetes termina el pod viejo (graceful shutdown, 30s)
+        |
+12. Traefik enruta david-whoop-dev.apptolast.com al Service
+        |
+13. Usuario accede a https://david-whoop-dev.apptolast.com/api/v1/cycles
+```
+
+---
+
+## 7. Documentacion oficial
+
+- [Docker - Dockerfile reference](https://docs.docker.com/reference/dockerfile/)
+- [Docker - Multi-stage builds](https://docs.docker.com/build/building/multi-stage/)
+- [Kubernetes - Conceptos](https://kubernetes.io/docs/concepts/)
+- [Kubernetes - Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [Kubernetes - StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+- [Kubernetes - Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [Kubernetes - ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [Kubernetes - Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [Kubernetes - Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+- [Kubernetes - PersistentVolumeClaims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- [Traefik - IngressRoute](https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/)
+- [cert-manager - Certificate](https://cert-manager.io/docs/usage/certificate/)
+- [Longhorn - Documentacion](https://longhorn.io/docs/)
+- [Keel - Documentacion](https://keel.sh/docs/)
+- [Spring Boot - Docker](https://docs.spring.io/spring-boot/reference/packaging/container-images/dockerfiles.html)
+- [Eclipse Temurin](https://adoptium.net/)

--- a/docs/14-cicd.md
+++ b/docs/14-cicd.md
@@ -1,0 +1,824 @@
+# 14. CI/CD con GitHub Actions
+
+## Indice
+
+1. [Que es CI/CD](#1-que-es-cicd)
+2. [Donde se usa en nuestro proyecto](#2-donde-se-usa-en-nuestro-proyecto)
+3. [Los 3 workflows y como se encadenan](#3-los-3-workflows-y-como-se-encadenan)
+4. [Workflow 1: CI (Continuous Integration)](#4-workflow-1-ci-continuous-integration)
+5. [Workflow 2: CD (Continuous Deployment)](#5-workflow-2-cd-continuous-deployment)
+6. [Workflow 3: Update API Documentation](#6-workflow-3-update-api-documentation)
+7. [Flujo completo del pipeline](#7-flujo-completo-del-pipeline)
+8. [Conceptos de GitHub Actions explicados](#8-conceptos-de-github-actions-explicados)
+9. [Documentacion oficial](#9-documentacion-oficial)
+
+---
+
+## 1. Que es CI/CD
+
+**CI (Continuous Integration)**: cada vez que alguien hace push o abre un pull request, se ejecutan automaticamente los tests y la compilacion. Si algo falla, el equipo lo sabe de inmediato.
+
+**CD (Continuous Deployment)**: despues de que CI pasa, se construye la imagen Docker y se sube a Docker Hub. Luego, Keel detecta la nueva imagen y actualiza el cluster de Kubernetes automaticamente.
+
+**El objetivo**: que cada cambio en el codigo llegue a produccion (o al entorno de dev) sin intervencion manual, pero con la garantia de que ha pasado los tests.
+
+---
+
+## 2. Donde se usa en nuestro proyecto
+
+Los workflows estan en `.github/workflows/`:
+
+```
+.github/workflows/
+├── ci.yml                  # Compilacion y tests
+├── cd.yml                  # Build Docker + push a Docker Hub
+└── update-api-docs.yml     # Actualiza OpenAPI spec y coleccion Postman
+```
+
+---
+
+## 3. Los 3 workflows y como se encadenan
+
+```
+                    PR creado/actualizado
+                           |
+                    +------v------+
+                    |    CI       |  Compila + ejecuta tests
+                    | (ci.yml)   |  Sube reportes como artefacto
+                    +------+------+
+                           |
+                     PR mergeado
+                     (push a dev/main)
+                           |
+              +------------+------------+
+              |                         |
+       +------v------+          +------v------+
+       |    CI       |          |    CD       |  Construye imagen Docker
+       | (ci.yml)    |          | (cd.yml)    |  Sube a Docker Hub
+       +-------------+          +------+------+
+                                       |
+                                       | workflow_run (completed)
+                                       |
+                                +------v------+
+                                | Update Docs |  Espera 60s al deploy
+                                | (update-    |  Descarga OpenAPI spec
+                                |  api-docs)  |  Genera coleccion Postman
+                                +-------------+  Commit al repositorio
+```
+
+**Importante**: CI y CD se ejecutan **en paralelo** cuando hay un push a `dev` o `main`. No dependen uno del otro. Update API Docs se ejecuta **despues** de que CD complete con exito.
+
+---
+
+## 4. Workflow 1: CI (Continuous Integration)
+
+**Archivo**: `.github/workflows/ci.yml`
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 24
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 24
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: ./gradlew build
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: build/reports/tests/
+          retention-days: 7
+```
+
+### Explicacion linea por linea
+
+#### Triggers (`on`)
+
+```yaml
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [dev]
+```
+
+- **`pull_request: branches: [main, dev]`**: se ejecuta cuando se crea o actualiza un PR hacia `main` o `dev`. Esto permite verificar el codigo ANTES de mergearlo.
+- **`push: branches: [dev]`**: se ejecuta cuando hay un push directo a `dev` (incluye merges de PRs).
+- **No hay `push: branches: [main]`**: los pushes a `main` solo se hacen via PR (que ya ejecuto CI en el PR). El CD si se ejecuta en pushes a `main`.
+
+#### Permisos
+
+```yaml
+permissions:
+  contents: read
+```
+
+- El workflow solo necesita **leer** el repositorio (checkout del codigo). No necesita escribir.
+- **Principio de minimo privilegio**: si el workflow se compromete, no puede modificar el repositorio.
+
+#### Steps
+
+**Step 1: Checkout**
+```yaml
+- name: Checkout
+  uses: actions/checkout@v4
+```
+Descarga el codigo del repositorio en el runner. Sin esto, el runner esta vacio.
+
+**Step 2: Setup Java**
+```yaml
+- name: Setup Java 24
+  uses: actions/setup-java@v4
+  with:
+    distribution: temurin
+    java-version: 24
+```
+Instala Java 24 (Eclipse Temurin) en el runner. Los runners de GitHub Actions vienen con Java pero no necesariamente la version correcta.
+
+**Step 3: Setup Gradle**
+```yaml
+- name: Setup Gradle
+  uses: gradle/actions/setup-gradle@v4
+```
+Configura Gradle con caching automatico. Las dependencias descargadas se cachean entre ejecuciones para acelerar los builds.
+
+**Step 4: Build and test**
+```yaml
+- name: Build and test
+  run: ./gradlew build
+```
+`./gradlew build` hace todo: compila Kotlin, ejecuta kapt (MapStruct), compila tests, ejecuta tests, y genera reportes. Si cualquier test falla, el step falla y el workflow se marca como fallido.
+
+**Step 5: Upload test reports**
+```yaml
+- name: Upload test reports
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: test-reports
+    path: build/reports/tests/
+    retention-days: 7
+```
+- **`if: always()`**: se ejecuta SIEMPRE, incluso si el build fallo. Asi puedes ver los reportes de test para diagnosticar fallos.
+- **`actions/upload-artifact@v4`**: sube los reportes HTML de tests como un artefacto descargable desde la UI de GitHub Actions.
+- **`retention-days: 7`**: los artefactos se borran despues de 7 dias para no consumir almacenamiento.
+
+---
+
+## 5. Workflow 2: CD (Continuous Deployment)
+
+**Archivo**: `.github/workflows/cd.yml`
+
+```yaml
+name: CD
+
+on:
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 24
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 24
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build (skip tests - already passed in CI)
+        run: ./gradlew bootJar -x test
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "tags=apptolast/whoop-david-api:latest,apptolast/whoop-david-api:${{ github.sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "dev" ]; then
+            echo "tags=apptolast/whoop-david-api:develop,apptolast/whoop-david-api:dev-${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+### Explicacion linea por linea
+
+#### Trigger
+
+```yaml
+on:
+  push:
+    branches: [main, dev]
+```
+
+Solo se ejecuta en pushes a `main` o `dev`. No se ejecuta en PRs (no queremos publicar imagenes Docker de codigo no mergeado).
+
+#### Build del JAR (sin tests)
+
+```yaml
+- name: Build (skip tests - already passed in CI)
+  run: ./gradlew bootJar -x test
+```
+
+- `bootJar` genera el fat JAR de Spring Boot.
+- `-x test` salta los tests. Ya se ejecutaron en el workflow CI (que corre en paralelo).
+- **Por que no reutilizar el JAR de CI**: cada workflow se ejecuta en un runner distinto. No comparten archivos.
+
+#### Login en Docker Hub
+
+```yaml
+- name: Login to Docker Hub
+  uses: docker/login-action@v3
+  with:
+    username: ${{ secrets.DOCKERHUB_USERNAME }}
+    password: ${{ secrets.DOCKERHUB_TOKEN }}
+```
+
+- **`${{ secrets.DOCKERHUB_USERNAME }}`** y **`${{ secrets.DOCKERHUB_TOKEN }}`**: secretos configurados en GitHub (Settings > Secrets and variables > Actions).
+- Se usa un Access Token de Docker Hub, no la contrasena directa.
+
+#### Docker Buildx
+
+```yaml
+- name: Set up Docker Buildx
+  uses: docker/setup-buildx-action@v3
+```
+
+Buildx es una extension de Docker que permite builds avanzados: caching en GitHub Actions, builds multi-plataforma, etc.
+
+#### Estrategia de tags
+
+```yaml
+- name: Determine Docker tags
+  id: tags
+  run: |
+    if [ "${{ github.ref_name }}" = "main" ]; then
+      echo "tags=apptolast/whoop-david-api:latest,apptolast/whoop-david-api:${{ github.sha }}" >> $GITHUB_OUTPUT
+    elif [ "${{ github.ref_name }}" = "dev" ]; then
+      echo "tags=apptolast/whoop-david-api:develop,apptolast/whoop-david-api:dev-${{ github.sha }}" >> $GITHUB_OUTPUT
+    fi
+```
+
+| Rama | Tags generados | Keel detecta | Despliega en |
+|------|---------------|--------------|--------------|
+| `main` | `latest` + `<sha-completo>` | `latest` | Produccion (`apptolast-whoop-david-api-prod`) |
+| `dev` | `develop` + `dev-<sha-completo>` | `develop` | Dev (`apptolast-whoop-david-api-dev`) |
+
+**Por que 2 tags**:
+- El tag mutable (`latest` / `develop`) es el que Keel vigila para auto-deploy.
+- El tag con SHA (`abc123...` / `dev-abc123...`) es inmutable y permite hacer rollback a una version exacta.
+
+**`$GITHUB_OUTPUT`**: es la forma de pasar valores entre steps en GitHub Actions. El step `tags` escribe el valor; el step `Build and push` lo lee con `${{ steps.tags.outputs.tags }}`.
+
+#### Build y push de la imagen Docker
+
+```yaml
+- name: Build and push
+  uses: docker/build-push-action@v6
+  with:
+    context: .
+    push: true
+    tags: ${{ steps.tags.outputs.tags }}
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+- **`context: .`**: usa el directorio raiz del repo como contexto de Docker (donde esta el `Dockerfile`).
+- **`push: true`**: sube la imagen a Docker Hub despues de construirla.
+- **`tags`**: los tags calculados en el step anterior.
+- **`cache-from: type=gha`** y **`cache-to: type=gha,mode=max`**: usa el cache de GitHub Actions para las capas de Docker. Esto acelera mucho los builds (las capas de dependencias no se reconstruyen si no cambiaron).
+
+**`mode=max`**: cachea todas las capas intermedias, no solo las del resultado final. Util para multi-stage builds porque cachea tambien las capas del builder.
+
+---
+
+## 6. Workflow 3: Update API Documentation
+
+**Archivo**: `.github/workflows/update-api-docs.yml`
+
+```yaml
+name: Update API Documentation
+
+on:
+  workflow_run:
+    workflows: ["CD"]
+    types:
+      - completed
+    branches:
+      - main
+      - dev
+
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Entorno desde el cual obtener la spec'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - prod
+
+permissions:
+  contents: write
+
+env:
+  API_URL_DEV: https://david-whoop-dev.apptolast.com
+  API_URL_PROD: https://david-whoop.apptolast.com
+```
+
+### Trigger: `workflow_run`
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["CD"]
+    types: [completed]
+    branches: [main, dev]
+```
+
+- **`workflow_run`**: se ejecuta DESPUES de que otro workflow termine.
+- **`workflows: ["CD"]`**: se dispara cuando el workflow llamado "CD" completa.
+- **`types: [completed]`**: se ejecuta tanto si CD tuvo exito como si fallo. La condicion `if` del job filtra solo los exitosos.
+- **`branches: [main, dev]`**: solo si el CD fue para estas ramas.
+
+```yaml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Entorno desde el cual obtener la spec'
+        required: true
+        default: 'dev'
+        type: choice
+        options: [dev, prod]
+```
+
+- **`workflow_dispatch`**: permite ejecutar el workflow manualmente desde la UI de GitHub Actions.
+- Define un input `environment` con un selector de opciones.
+
+### Permisos de escritura
+
+```yaml
+permissions:
+  contents: write
+```
+
+Este workflow necesita **escribir** en el repositorio porque hace commit de los archivos generados (OpenAPI spec y coleccion Postman).
+
+### Job: update-docs
+
+```yaml
+jobs:
+  update-docs:
+    name: Update OpenAPI & Postman Collection
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+```
+
+- **`if: ... conclusion == 'success'`**: solo se ejecuta si el workflow CD fue exitoso. Si CD fallo, no tiene sentido intentar actualizar la documentacion.
+- **`|| github.event_name == 'workflow_dispatch'`**: tambien se ejecuta si se lanzo manualmente.
+
+### Steps explicados
+
+**Step 1: Checkout**
+```yaml
+- name: Checkout repository
+  uses: actions/checkout@v4
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+```
+- **`ref`**: hace checkout de la rama que disparo el workflow CD, no de la rama por defecto. Asi el commit se hace en la rama correcta.
+
+**Step 2-3: Setup Node.js + Install openapi2postmanv2**
+```yaml
+- name: Setup Node.js
+  uses: actions/setup-node@v4
+  with:
+    node-version: '20'
+
+- name: Install openapi-to-postmanv2
+  run: npm install -g openapi-to-postmanv2
+```
+La herramienta `openapi2postmanv2` convierte un spec OpenAPI a una coleccion Postman. Es una herramienta de Node.js.
+
+**Step 4: Determinar URL de la API**
+```yaml
+- name: Determine API URL
+  id: api-url
+  run: |
+    if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+      ENV="${{ github.event.inputs.environment }}"
+    elif [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+      ENV="prod"
+    else
+      ENV="dev"
+    fi
+
+    if [ "$ENV" = "prod" ]; then
+      echo "url=${{ env.API_URL_PROD }}" >> $GITHUB_OUTPUT
+    else
+      echo "url=${{ env.API_URL_DEV }}" >> $GITHUB_OUTPUT
+    fi
+    echo "env=$ENV" >> $GITHUB_OUTPUT
+```
+
+| Rama | URL |
+|------|-----|
+| `main` | `https://david-whoop.apptolast.com` |
+| `dev` | `https://david-whoop-dev.apptolast.com` |
+
+**Step 5: Esperar al deploy**
+```yaml
+- name: Wait for API deployment
+  run: |
+    echo "Esperando 60 segundos para que el deployment complete..."
+    sleep 60
+```
+Keel tarda ~1 minuto en detectar la imagen nueva y desplegar. Este sleep da tiempo a que el pod nuevo arranque.
+
+**Step 6: Descargar OpenAPI spec**
+```yaml
+- name: Fetch OpenAPI spec
+  id: fetch-spec
+  run: |
+    API_URL="${{ steps.api-url.outputs.url }}"
+    echo "Obteniendo OpenAPI spec desde: $API_URL/v3/api-docs"
+
+    for i in 1 2 3; do
+      HTTP_CODE=$(curl -s -w "%{http_code}" -o openapi.json "$API_URL/v3/api-docs")
+      if [ "$HTTP_CODE" = "200" ]; then
+        echo "OpenAPI spec obtenido exitosamente"
+        cat openapi.json | jq '.' > openapi_formatted.json
+        mv openapi_formatted.json openapi.json
+        break
+      fi
+      echo "Intento $i fallido (HTTP $HTTP_CODE), esperando 30 segundos..."
+      sleep 30
+    done
+
+    if [ ! -s openapi.json ]; then
+      echo "Error: No se pudo obtener el OpenAPI spec"
+      exit 1
+    fi
+```
+
+- Hace hasta 3 intentos de descargar `/v3/api-docs` (endpoint de springdoc-openapi).
+- Si el primer intento falla (la API puede no estar lista), espera 30 segundos y reintenta.
+- Formatea el JSON con `jq` para facilitar los diffs en Git.
+
+**Step 7: Generar coleccion Postman**
+```yaml
+- name: Generate Postman Collection
+  run: |
+    openapi2postmanv2 \
+      -s openapi.json \
+      -o WhoopDavidAPI_Collection_NEW.postman_collection.json \
+      -p \
+      -O folderStrategy=Tags,includeAuthInfoInExample=true
+```
+- `-s`: archivo fuente (OpenAPI spec).
+- `-o`: archivo de salida.
+- `-p`: pretty print.
+- `-O folderStrategy=Tags`: organiza las peticiones por tags (en vez de por paths).
+- `includeAuthInfoInExample=true`: incluye la autenticacion en los ejemplos.
+
+**Step 8: Detectar cambios**
+```yaml
+- name: Check for changes
+  id: changes
+  run: |
+    git add openapi.json WhoopDavidAPI_Collection.postman_collection.json
+    git diff --staged --quiet || echo "changed=true" >> $GITHUB_OUTPUT
+```
+
+- **`git add`**: agrega los archivos al staging area. Esto es importante porque pueden ser archivos **nuevos** (que `git diff` sin `--staged` no detectaria).
+- **`git diff --staged --quiet`**: retorna exit code 0 si no hay cambios, 1 si hay cambios.
+- **`|| echo "changed=true"`**: si hay cambios, setea la variable `changed` para el siguiente step.
+
+**Por que `git add` + `git diff --staged` en vez de `git diff --quiet`**: `git diff --quiet` solo detecta cambios en archivos ya trackeados. Si `openapi.json` es un archivo nuevo (primera vez que se genera), `git diff --quiet` no lo detectaria. `git add` primero y `git diff --staged` despues detecta tanto archivos nuevos como modificados.
+
+**Step 9: Commit y push**
+```yaml
+- name: Commit and push changes
+  if: steps.changes.outputs.changed == 'true'
+  run: |
+    git config --local user.email "github-actions[bot]@users.noreply.github.com"
+    git config --local user.name "github-actions[bot]"
+
+    BRANCH="${{ github.event.workflow_run.head_branch || github.ref_name }}"
+    ENV="${{ steps.api-url.outputs.env }}"
+
+    git commit -m "docs: auto-update OpenAPI spec and Postman collection
+
+    - Updated from $ENV environment API
+    - Branch: $BRANCH
+    - Generated by GitHub Actions
+
+    Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+
+    git push
+```
+
+- Solo se ejecuta si hubo cambios (`if: steps.changes.outputs.changed == 'true'`).
+- Configura el usuario de Git como `github-actions[bot]` para que los commits aparezcan como automaticos.
+- Hace commit y push directamente a la rama.
+
+**Step 10: Summary**
+```yaml
+- name: Summary
+  run: |
+    echo "## API Documentation Update" >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+    echo "| Item | Status |" >> $GITHUB_STEP_SUMMARY
+    ...
+```
+
+- **`$GITHUB_STEP_SUMMARY`**: genera un resumen visible en la pagina del workflow en GitHub. Es una tabla markdown con el resultado de la ejecucion.
+
+---
+
+## 7. Flujo completo del pipeline
+
+### Cuando se crea un PR hacia `dev` o `main`
+
+```
+1. Developer crea/actualiza PR
+2. CI workflow se ejecuta:
+   - Compila el proyecto
+   - Ejecuta los 9 tests
+   - Sube reportes de test como artefacto
+3. GitHub muestra check verde/rojo en el PR
+4. Si es verde, el PR se puede mergear
+```
+
+### Cuando se mergea un PR a `dev`
+
+```
+1. Push a dev (merge del PR)
+        |
+        +---> CI workflow: compila + tests (redundante pero seguro)
+        |
+        +---> CD workflow (en paralelo):
+                |
+                1. ./gradlew bootJar -x test
+                2. docker login (Docker Hub)
+                3. Calcula tags: develop + dev-<sha>
+                4. docker build + push
+                |
+                +---> Imagen en Docker Hub: apptolast/whoop-david-api:develop
+                        |
+                        +---> Keel detecta (~1 min)
+                        |     Actualiza Deployment en apptolast-whoop-david-api-dev
+                        |     Rolling update: nuevo pod arranca, viejo se elimina
+                        |
+                        +---> Update API Docs workflow (tras CD exitoso):
+                              1. Espera 60s
+                              2. GET https://david-whoop-dev.apptolast.com/v3/api-docs
+                              3. Convierte a coleccion Postman
+                              4. Commit + push al repo
+```
+
+### Cuando se mergea un PR a `main`
+
+```
+1. Push a main (merge del PR)
+        |
+        +---> CD workflow:
+                |
+                1. Calcula tags: latest + <sha>
+                2. docker build + push
+                |
+                +---> Imagen en Docker Hub: apptolast/whoop-david-api:latest
+                        |
+                        +---> Keel detecta (~1 min)
+                        |     Actualiza Deployment en apptolast-whoop-david-api-prod
+                        |
+                        +---> Update API Docs workflow:
+                              1. GET https://david-whoop.apptolast.com/v3/api-docs
+                              2. Commit coleccion Postman actualizada
+```
+
+### Resumen visual
+
+```
+                     PR a dev/main
+                          |
+                    +-----v-----+
+                    |    CI     |  ./gradlew build
+                    +-----------+  (upload test reports)
+                          |
+                    merge a dev/main
+                          |
+              +-----------+-----------+
+              |                       |
+        +-----v-----+          +-----v-----+
+        |    CI     |          |    CD     |  bootJar + docker push
+        +-----------+          +-----+-----+
+                                     |
+                               +-----v-----+
+                               | Update    |  OpenAPI + Postman
+                               | API Docs  |
+                               +-----------+
+                                     |
+                          Keel detecta imagen nueva
+                                     |
+                          Kubernetes hace rolling update
+                                     |
+                          App desplegada en K8s
+```
+
+---
+
+## 8. Conceptos de GitHub Actions explicados
+
+### Workflows, Jobs y Steps
+
+```
+Workflow (.yml file)
+  └── Job (runs on a runner)
+       └── Step 1 (action o comando)
+       └── Step 2
+       └── Step 3
+```
+
+- **Workflow**: un archivo YAML en `.github/workflows/`. Define cuando y que se ejecuta.
+- **Job**: un grupo de steps que se ejecutan en el mismo runner (maquina virtual). Jobs diferentes pueden correr en paralelo.
+- **Step**: una accion individual (ejecutar un comando, usar una action).
+
+### `actions/...` (Actions reutilizables)
+
+Las actions son bloques de funcionalidad reutilizables, publicadas por la comunidad o por GitHub:
+
+| Action | Version | Funcion |
+|--------|---------|---------|
+| `actions/checkout@v4` | v4 | Descarga el codigo del repo |
+| `actions/setup-java@v4` | v4 | Instala una version de Java |
+| `gradle/actions/setup-gradle@v4` | v4 | Configura Gradle con cache |
+| `actions/upload-artifact@v4` | v4 | Sube archivos como artefactos |
+| `docker/login-action@v3` | v3 | Login en un registry de Docker |
+| `docker/setup-buildx-action@v3` | v3 | Configura Docker Buildx |
+| `docker/build-push-action@v6` | v6 | Build + push de imagen Docker |
+| `actions/setup-node@v4` | v4 | Instala Node.js |
+
+### `secrets` (Secretos)
+
+Los secretos se configuran en GitHub (Settings > Secrets and variables > Actions) y se referencian como `${{ secrets.NOMBRE }}`.
+
+Secretos usados en nuestro proyecto:
+
+| Secreto | Usado en | Proposito |
+|---------|----------|-----------|
+| `DOCKERHUB_USERNAME` | CD | Usuario de Docker Hub |
+| `DOCKERHUB_TOKEN` | CD | Access Token de Docker Hub |
+| `GITHUB_TOKEN` | Update API Docs | Token automatico de GitHub para hacer push |
+
+**`GITHUB_TOKEN`** es especial: GitHub lo genera automaticamente para cada ejecucion del workflow. No necesitas configurarlo manualmente.
+
+### `permissions`
+
+Controla que puede hacer el workflow con los permisos del `GITHUB_TOKEN`:
+
+```yaml
+permissions:
+  contents: read    # CI y CD: solo leer el repo
+```
+
+```yaml
+permissions:
+  contents: write   # Update API Docs: necesita escribir (commit + push)
+```
+
+### `$GITHUB_OUTPUT` (comunicacion entre steps)
+
+```yaml
+# Step 1: escribe
+echo "tags=apptolast/whoop-david-api:latest" >> $GITHUB_OUTPUT
+
+# Step 2: lee
+tags: ${{ steps.tags.outputs.tags }}
+```
+
+`$GITHUB_OUTPUT` es un archivo especial donde un step puede escribir pares clave=valor. Otros steps del mismo job pueden leer esos valores con `${{ steps.<id>.outputs.<clave> }}`.
+
+### `$GITHUB_STEP_SUMMARY`
+
+```yaml
+echo "## Titulo" >> $GITHUB_STEP_SUMMARY
+echo "| Col1 | Col2 |" >> $GITHUB_STEP_SUMMARY
+```
+
+Genera un resumen en markdown visible en la pagina del workflow en GitHub. Util para mostrar informacion resumida del resultado.
+
+### `if: always()` y `if: steps.X.outputs.Y == 'true'`
+
+```yaml
+- name: Upload test reports
+  if: always()  # Se ejecuta incluso si steps anteriores fallaron
+```
+
+```yaml
+- name: Commit and push
+  if: steps.changes.outputs.changed == 'true'  # Solo si hubo cambios
+```
+
+Los steps se pueden condicionar con expresiones. `always()` garantiza la ejecucion aunque el workflow este fallando.
+
+### Docker layer caching con `type=gha`
+
+```yaml
+cache-from: type=gha
+cache-to: type=gha,mode=max
+```
+
+- **`type=gha`**: usa el cache de GitHub Actions (no Docker Hub ni un registry externo).
+- **`cache-from`**: al construir, busca capas cacheadas en GitHub.
+- **`cache-to`**: despues de construir, sube las capas nuevas al cache.
+- **`mode=max`**: cachea TODAS las capas intermedias (incluidas las del builder stage en un multi-stage build).
+
+**Resultado**: si solo cambio el codigo fuente (no las dependencias), Docker reutiliza la capa de `./gradlew dependencies` del cache, ahorrando varios minutos.
+
+### `workflow_run` (encadenar workflows)
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["CD"]
+    types: [completed]
+    branches: [main, dev]
+```
+
+Es la forma de ejecutar un workflow DESPUES de que otro termine. A diferencia de poner todo en un solo workflow, permite:
+- Que cada workflow tenga permisos diferentes (`read` vs `write`).
+- Que los workflows sean independientes y reutilizables.
+- Que el tercer workflow solo se ejecute si el segundo (CD) fue exitoso.
+
+**Atencion**: `types: [completed]` se ejecuta tanto si fue exitoso como si fallo. Por eso el job tiene `if: github.event.workflow_run.conclusion == 'success'`.
+
+---
+
+## 9. Documentacion oficial
+
+- [GitHub Actions - Documentacion](https://docs.github.com/en/actions)
+- [GitHub Actions - Workflow syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
+- [GitHub Actions - Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
+- [GitHub Actions - Encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+- [GitHub Actions - workflow_run event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)
+- [GitHub Actions - GITHUB_OUTPUT](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)
+- [docker/build-push-action](https://github.com/docker/build-push-action)
+- [docker/login-action](https://github.com/docker/login-action)
+- [gradle/actions/setup-gradle](https://github.com/gradle/actions/tree/main/setup-gradle)
+- [Keel - Policies](https://keel.sh/docs/#policies)


### PR DESCRIPTION
## Summary
- 15 comprehensive learning documentation files in Spanish
- Covers every Spring Boot concept used in the project
- Each guide follows: What is it? → Where used? → Why? → Code explained → Official docs
- 7,512 lines of educational content with code examples from the actual codebase

## Documentation Index
| # | File | Topic |
|---|------|-------|
| 00 | `00-indice.md` | Index and project overview |
| 01 | `01-arquitectura.md` | Architecture and BFF pattern |
| 02 | `02-gradle-dependencias.md` | Gradle build and dependencies |
| 03 | `03-entidades-jpa.md` | JPA entities and Hibernate |
| 04 | `04-repositorios.md` | Spring Data JPA repositories |
| 05 | `05-dtos-mapstruct.md` | DTOs and MapStruct mapping |
| 06 | `06-servicios.md` | Service layer and business logic |
| 07 | `07-controladores.md` | REST controllers and exception handling |
| 08 | `08-seguridad.md` | Spring Security (Basic Auth + OAuth2 + AES-256) |
| 09 | `09-cliente-http.md` | RestClient and Resilience4j |
| 10 | `10-sincronizacion.md` | Scheduled sync with Whoop API |
| 11 | `11-perfiles.md` | Spring Profiles (dev/prod/demo) |
| 12 | `12-testing.md` | Testing with Spring Boot 4 |
| 13 | `13-docker-k8s.md` | Docker and Kubernetes deployment |
| 14 | `14-cicd.md` | CI/CD with GitHub Actions |

## Test plan
- [x] `./gradlew build` passes (0 errors, 0 warnings)
- [x] All 9 tests pass
- [x] All docs reference real source files with relative paths
- [x] Links to official Spring Boot documentation included

🤖 Generated with [Claude Code](https://claude.com/claude-code)