### PR TITLE
ci: add docs link checker to verify learning docs stay in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build and test
         run: ./gradlew build
 
+      - name: Check docs links
+        run: ./scripts/check-docs-links.sh
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/check-docs-links.sh
+++ b/scripts/check-docs-links.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Script: Verificar que los links relativos en docs/ apuntan a ficheros existentes
+# Uso: ./scripts/check-docs-links.sh
+# Exit code: 0 si todos los links son validos, 1 si hay links rotos
+
+set -euo pipefail
+
+DOCS_DIR="docs"
+BROKEN=0
+TOTAL=0
+BROKEN_LIST=""
+
+# Extraer todos los links relativos de los ficheros markdown
+# Formato: [texto](../ruta/al/fichero)
+for doc in "$DOCS_DIR"/*.md; do
+    # Extraer rutas relativas (../algo) de links markdown
+    links=$(grep -oP '\]\(\.\./[^)]+\)' "$doc" | grep -oP '\.\./[^)]+' || true)
+
+    for link in $links; do
+        TOTAL=$((TOTAL + 1))
+        # Resolver ruta relativa desde docs/
+        resolved="$DOCS_DIR/$link"
+        # Normalizar (eliminar ../)
+        normalized=$(realpath --relative-to=. "$resolved" 2>/dev/null || echo "$resolved")
+
+        if [ ! -f "$normalized" ] && [ ! -d "$normalized" ]; then
+            BROKEN=$((BROKEN + 1))
+            BROKEN_LIST="${BROKEN_LIST}\n  - ${doc}: ${link} -> ${normalized}"
+        fi
+    done
+done
+
+echo "Docs link check: $TOTAL links verificados, $BROKEN rotos"
+
+if [ $BROKEN -gt 0 ]; then
+    echo -e "\nLinks rotos:${BROKEN_LIST}"
+    echo ""
+    echo "Los ficheros fuente referenciados en docs/ han cambiado o no existen."
+    echo "Actualiza los docs para reflejar la estructura actual del proyecto."
+    exit 1
+fi
+
+echo "Todos los links en docs/ son validos."
+exit 0


### PR DESCRIPTION
## Summary
- Adds `scripts/check-docs-links.sh` that verifies all 78 relative links in `docs/` point to existing files
- Integrates the check into the CI workflow (runs after build, before test reports)
- If a source file is renamed/deleted, CI fails and tells you which docs need updating

## How it works
```
./scripts/check-docs-links.sh
# Docs link check: 78 links verificados, 0 rotos
# Todos los links en docs/ son validos.
```

## Test plan
- [x] `./gradlew build` passes
- [x] `./scripts/check-docs-links.sh` passes (78 links, 0 broken)
- [x] Script correctly detects broken links (tested by renaming a file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)